### PR TITLE
Remove app_name string

### DIFF
--- a/ticker/src/main/res/values/strings.xml
+++ b/ticker/src/main/res/values/strings.xml
@@ -1,3 +1,0 @@
-<resources>
-    <string name="app_name">Ticker</string>
-</resources>


### PR DESCRIPTION
This removes the app_name string resource, so that it does not collide with other apps resources