### PR TITLE
Stop extending ArrayList in TickerColumnManager

### DIFF
--- a/ticker/src/main/java/com/robinhood/ticker/TickerColumnManager.java
+++ b/ticker/src/main/java/com/robinhood/ticker/TickerColumnManager.java
@@ -32,7 +32,8 @@ import java.util.Map;
  *
  * @author Jin Cao, Robinhood
  */
-class TickerColumnManager extends ArrayList<TickerColumn> {
+class TickerColumnManager {
+    final ArrayList<TickerColumn> tickerColumns = new ArrayList<>();
     private final TickerDrawMetrics metrics;
 
     // The character list that dictates how to transition from one character to another.
@@ -62,9 +63,9 @@ class TickerColumnManager extends ArrayList<TickerColumn> {
      */
     boolean shouldDebounceText(char[] text) {
         final int newTextSize = text.length;
-        if (newTextSize == size()) {
+        if (newTextSize == tickerColumns.size()) {
             for (int i = 0; i < newTextSize; i++) {
-                if (text[i] != get(i).getTargetChar()) {
+                if (text[i] != tickerColumns.get(i).getTargetChar()) {
                     return false;
                 }
             }
@@ -89,33 +90,33 @@ class TickerColumnManager extends ArrayList<TickerColumn> {
             ensureColumnSize(newTextSize);
         }
 
-        final int columnsSize = size();
+        final int columnsSize = tickerColumns.size();
         for (int i = 0; i < columnsSize; i++) {
-            get(i).setTargetChar(i < newTextSize ? text[i] : TickerUtils.EMPTY_CHAR);
+            tickerColumns.get(i).setTargetChar(i < newTextSize ? text[i] : TickerUtils.EMPTY_CHAR);
         }
 
         return true;
     }
 
     void setAnimationProgress(float animationProgress) {
-        for (int i = 0, size = size(); i < size; i++) {
-            final TickerColumn column = get(i);
+        for (int i = 0, size = tickerColumns.size(); i < size; i++) {
+            final TickerColumn column = tickerColumns.get(i);
             column.setAnimationProgress(animationProgress);
         }
     }
 
     float getMinimumRequiredWidth() {
         float width = 0f;
-        for (int i = 0, size = size(); i < size; i++) {
-            width += get(i).getMinimumRequiredWidth();
+        for (int i = 0, size = tickerColumns.size(); i < size; i++) {
+            width += tickerColumns.get(i).getMinimumRequiredWidth();
         }
         return width;
     }
 
     float getCurrentWidth() {
         float width = 0f;
-        for (int i = 0, size = size(); i < size; i++) {
-            width += get(i).getCurrentWidth();
+        for (int i = 0, size = tickerColumns.size(); i < size; i++) {
+            width += tickerColumns.get(i).getCurrentWidth();
         }
         return width;
     }
@@ -126,8 +127,8 @@ class TickerColumnManager extends ArrayList<TickerColumn> {
      * accordingly for the draw procedures.
      */
     void draw(Canvas canvas, Paint textPaint) {
-        for (int i = 0, size = size(); i < size; i++) {
-            final TickerColumn column = get(i);
+        for (int i = 0, size = tickerColumns.size(); i < size; i++) {
+            final TickerColumn column = tickerColumns.get(i);
             column.draw(canvas, textPaint);
             canvas.translate(column.getCurrentWidth(), 0f);
         }
@@ -137,12 +138,12 @@ class TickerColumnManager extends ArrayList<TickerColumn> {
      * Ensure that the number of columns matches {@param targetSize}.
      */
     void ensureColumnSize(int targetSize) {
-        final int columnSize = size();
+        final int columnSize = tickerColumns.size();
         if (targetSize > columnSize) {
             insertColumnsUpTo(targetSize);
         } else {
             for (int i = 0; i < columnSize - targetSize; i++) {
-                remove(size() - 1);
+                tickerColumns.remove(tickerColumns.size() - 1);
             }
         }
     }
@@ -151,11 +152,11 @@ class TickerColumnManager extends ArrayList<TickerColumn> {
      * Insert (if applicable) columns until the number of columns match {@param targetSize}.
      */
     void insertColumnsUpTo(int targetSize) {
-        final int currentSize = size();
+        final int currentSize = tickerColumns.size();
         if (targetSize > currentSize) {
             final int toInsert = targetSize - currentSize;
             for (int i = 0; i < toInsert; i++) {
-                add(new TickerColumn(characterList, characterIndicesMap, metrics));
+                tickerColumns.add(new TickerColumn(characterList, characterIndicesMap, metrics));
             }
         }
     }

--- a/ticker/src/test/java/com/robinhood/ticker/TickerColumnManagerTest.java
+++ b/ticker/src/test/java/com/robinhood/ticker/TickerColumnManagerTest.java
@@ -20,61 +20,61 @@ public class TickerColumnManagerTest {
 
     @Test
     public void test_insertColumnsUpTo() {
-        assertEquals(0, tickerColumnManager.size());
+        assertEquals(0, numberOfTickerColumns());
         tickerColumnManager.insertColumnsUpTo(2);
-        assertEquals(2, tickerColumnManager.size());
+        assertEquals(2, numberOfTickerColumns());
         tickerColumnManager.insertColumnsUpTo(5);
-        assertEquals(5, tickerColumnManager.size());
+        assertEquals(5, numberOfTickerColumns());
         tickerColumnManager.insertColumnsUpTo(1);
-        assertEquals(5, tickerColumnManager.size());
+        assertEquals(5, numberOfTickerColumns());
     }
 
     @Test
     public void test_ensureColumnSize() {
-        assertEquals(0, tickerColumnManager.size());
+        assertEquals(0, numberOfTickerColumns());
         tickerColumnManager.ensureColumnSize(2);
-        assertEquals(2, tickerColumnManager.size());
+        assertEquals(2, numberOfTickerColumns());
         tickerColumnManager.ensureColumnSize(5);
-        assertEquals(5, tickerColumnManager.size());
+        assertEquals(5, numberOfTickerColumns());
         tickerColumnManager.ensureColumnSize(1);
-        assertEquals(1, tickerColumnManager.size());
+        assertEquals(1, numberOfTickerColumns());
     }
 
     @Test
     public void test_setText_animate() {
-        assertEquals(0, tickerColumnManager.size());
+        assertEquals(0, numberOfTickerColumns());
 
         tickerColumnManager.setText("1234".toCharArray(), true);
-        assertEquals(4, tickerColumnManager.size());
-        assertEquals('1', tickerColumnManager.get(0).getTargetChar());
-        assertEquals('2', tickerColumnManager.get(1).getTargetChar());
-        assertEquals('3', tickerColumnManager.get(2).getTargetChar());
-        assertEquals('4', tickerColumnManager.get(3).getTargetChar());
+        assertEquals(4, numberOfTickerColumns());
+        assertEquals('1', tickerColumnAtIndex(0).getTargetChar());
+        assertEquals('2', tickerColumnAtIndex(1).getTargetChar());
+        assertEquals('3', tickerColumnAtIndex(2).getTargetChar());
+        assertEquals('4', tickerColumnAtIndex(3).getTargetChar());
 
         tickerColumnManager.setText("999".toCharArray(), true);
-        assertEquals(4, tickerColumnManager.size());
-        assertEquals('9', tickerColumnManager.get(0).getTargetChar());
-        assertEquals('9', tickerColumnManager.get(1).getTargetChar());
-        assertEquals('9', tickerColumnManager.get(2).getTargetChar());
-        assertEquals(TickerUtils.EMPTY_CHAR, tickerColumnManager.get(3).getTargetChar());
+        assertEquals(4, numberOfTickerColumns());
+        assertEquals('9', tickerColumnAtIndex(0).getTargetChar());
+        assertEquals('9', tickerColumnAtIndex(1).getTargetChar());
+        assertEquals('9', tickerColumnAtIndex(2).getTargetChar());
+        assertEquals(TickerUtils.EMPTY_CHAR, tickerColumnAtIndex(3).getTargetChar());
     }
 
     @Test
     public void test_setText_noAnimate() {
-        assertEquals(0, tickerColumnManager.size());
+        assertEquals(0, numberOfTickerColumns());
 
         tickerColumnManager.setText("1234".toCharArray(), false);
-        assertEquals(4, tickerColumnManager.size());
-        assertEquals('1', tickerColumnManager.get(0).getTargetChar());
-        assertEquals('2', tickerColumnManager.get(1).getTargetChar());
-        assertEquals('3', tickerColumnManager.get(2).getTargetChar());
-        assertEquals('4', tickerColumnManager.get(3).getTargetChar());
+        assertEquals(4, numberOfTickerColumns());
+        assertEquals('1', tickerColumnAtIndex(0).getTargetChar());
+        assertEquals('2', tickerColumnAtIndex(1).getTargetChar());
+        assertEquals('3', tickerColumnAtIndex(2).getTargetChar());
+        assertEquals('4', tickerColumnAtIndex(3).getTargetChar());
 
         tickerColumnManager.setText("999".toCharArray(), false);
-        assertEquals(3, tickerColumnManager.size());
-        assertEquals('9', tickerColumnManager.get(0).getTargetChar());
-        assertEquals('9', tickerColumnManager.get(1).getTargetChar());
-        assertEquals('9', tickerColumnManager.get(2).getTargetChar());
+        assertEquals(3, numberOfTickerColumns());
+        assertEquals('9', tickerColumnAtIndex(0).getTargetChar());
+        assertEquals('9', tickerColumnAtIndex(1).getTargetChar());
+        assertEquals('9', tickerColumnAtIndex(2).getTargetChar());
     }
 
     @Test
@@ -82,5 +82,13 @@ public class TickerColumnManagerTest {
         tickerColumnManager.setText("1234".toCharArray(), false);
         assertTrue(tickerColumnManager.shouldDebounceText("1234".toCharArray()));
         assertFalse(tickerColumnManager.shouldDebounceText("12345".toCharArray()));
+    }
+
+    private TickerColumn tickerColumnAtIndex(int index) {
+        return tickerColumnManager.tickerColumns.get(index);
+    }
+
+    private int numberOfTickerColumns() {
+        return tickerColumnManager.tickerColumns.size();
     }
 }


### PR DESCRIPTION
This is a textbook example for using composition over inheritance. By extending `ArrayList`, we were adding a bunch of unnecessary methods to this classes contract that is not needed. On top of that, it would be strange, and confusing, if someone was to do `List<TickerColumn> columns = new TickerColumnManager()`.

With this change, we are keeping the contract of this class concise and a lot easier to maintain in the future since we would not have to worry about maintaining the `ArrayList` contract.