### PR TITLE
Add support to `android:textAppearance`

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ You can customize the looks and feels of the `TickerView` via XML:
 
 ```xml
 android:gravity="center"
-app:ticker_textColor="@color/colorPrimary"
-app:ticker_textSize="16sp"
+android:textColor="@color/colorPrimary"
+android:textSize="16sp"
 app:ticker_animationDuration="1500"
 ```
 
@@ -64,6 +64,8 @@ tickerView.setAnimationDuration(500);
 tickerView.setAnimationInterpolator(new OvershootInterpolator());
 tickerView.setGravity(Gravity.START);
 ```
+
+Note that you can also specify `android:textColor` and `android:textSize` attributes using `android:textAppearance` and provide it with an appropriate style.
 
 
 Performance
@@ -88,9 +90,6 @@ License
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
-
-
-
 
 
 

--- a/ticker-sample/src/main/res/layout/activity_main.xml
+++ b/ticker-sample/src/main/res/layout/activity_main.xml
@@ -2,7 +2,6 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical">
 
     <com.robinhood.ticker.TickerView
@@ -11,8 +10,7 @@
         android:layout_height="wrap_content"
         android:gravity="center"
         android:padding="@dimen/activity_vertical_margin"
-        app:ticker_textColor="@color/colorPrimary"
-        app:ticker_textSize="50sp" />
+        android:textAppearance="@style/TickerTextAppearance" />
 
     <com.robinhood.ticker.TickerView
         android:id="@+id/ticker2"
@@ -20,8 +18,7 @@
         android:layout_height="wrap_content"
         android:gravity="center"
         android:padding="@dimen/activity_vertical_margin"
-        app:ticker_textColor="@color/colorPrimary"
-        app:ticker_textSize="50sp" />
+        android:textAppearance="@style/TickerTextAppearance" />
 
     <com.robinhood.ticker.TickerView
         android:id="@+id/ticker3"
@@ -29,8 +26,7 @@
         android:layout_height="wrap_content"
         android:gravity="center"
         android:padding="@dimen/activity_vertical_margin"
-        app:ticker_textColor="@color/colorPrimary"
-        app:ticker_textSize="50sp" />
+        android:textAppearance="@style/TickerTextAppearance" />
 
     <Button
         android:id="@+id/perfBtn"

--- a/ticker-sample/src/main/res/values/styles.xml
+++ b/ticker-sample/src/main/res/values/styles.xml
@@ -8,4 +8,9 @@
         <item name="colorAccent">@color/colorAccent</item>
     </style>
 
+    <style name="TickerTextAppearance">
+        <item name="android:textColor">?colorPrimary</item>
+        <item name="android:textSize">50sp</item>
+    </style>
+
 </resources>

--- a/ticker/src/main/java/com/robinhood/ticker/TickerView.java
+++ b/ticker/src/main/java/com/robinhood/ticker/TickerView.java
@@ -109,22 +109,48 @@ public class TickerView extends View {
     protected void init(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
         final Resources res = context.getResources();
 
+        int textColor = DEFAULT_TEXT_COLOR;
+        float textSize = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_SP, DEFAULT_TEXT_SIZE,
+                res.getDisplayMetrics());
+        int animationDurationInMillis = DEFAULT_ANIMATION_DURATION;
+        int gravity = DEFAULT_GRAVITY;
+
         // Set the view attributes from XML or from default values defined in this class
         final TypedArray arr = context.obtainStyledAttributes(attrs, R.styleable.ticker_TickerView,
                 defStyleAttr, defStyleRes);
 
-        final int textColor = arr.getColor(R.styleable.ticker_TickerView_ticker_textColor,
-                DEFAULT_TEXT_COLOR);
-        setTextColor(textColor);
-        final float textSize = arr.getDimension(R.styleable.ticker_TickerView_ticker_textSize,
-                TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_SP, DEFAULT_TEXT_SIZE,
-                        res.getDisplayMetrics()));
-        setTextSize(textSize);
+        final int textAppearanceResId = arr.getResourceId(
+                R.styleable.ticker_TickerView_android_textAppearance, -1);
 
+        // Check textAppearance first
+        if (textAppearanceResId != -1) {
+            final TypedArray textAppearanceArr = context.obtainStyledAttributes(
+                    textAppearanceResId,
+                    new int[] {
+                            // TODO: having textColor first here does not work, why?
+                            android.R.attr.textSize,
+                            android.R.attr.textColor,
+                    });
+
+            textSize = textAppearanceArr.getDimension(0, textSize);
+            textColor = textAppearanceArr.getColor(1, textColor);
+
+            textAppearanceArr.recycle();
+        }
+
+        // Custom set attributes on the view should override textAppearance if applicable.
         animationDurationInMillis = arr.getInt(
-                R.styleable.ticker_TickerView_ticker_animationDuration, DEFAULT_ANIMATION_DURATION);
+                R.styleable.ticker_TickerView_ticker_animationDuration, animationDurationInMillis);
+        gravity = arr.getInt(R.styleable.ticker_TickerView_android_gravity, gravity);
+        textColor = arr.getColor(R.styleable.ticker_TickerView_android_textColor, textColor);
+        textSize = arr.getDimension(R.styleable.ticker_TickerView_android_textSize, textSize);
+
+        // After we've fetched the correct values for the attributes, set them on the view
         animationInterpolator = DEFAULT_ANIMATION_INTERPOLATOR;
-        gravity = arr.getInt(R.styleable.ticker_TickerView_android_gravity, DEFAULT_GRAVITY);
+        this.animationDurationInMillis = animationDurationInMillis;
+        this.gravity = gravity;
+        setTextColor(textColor);
+        setTextSize(textSize);
 
         arr.recycle();
 

--- a/ticker/src/main/res/values/attrs.xml
+++ b/ticker/src/main/res/values/attrs.xml
@@ -1,9 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
     <declare-styleable name="ticker_TickerView">
-        <attr name="ticker_textColor" format="reference|color" />
-        <attr name="ticker_textSize" format="reference|dimension" />
         <attr name="ticker_animationDuration" format="reference|integer" />
+
+        <!-- Custom implementations of common android text attributes -->
         <attr name="android:gravity" tools:ignore="ResourceName" />
+        <attr name="android:textAppearance" tools:ignore="ResourceName" />
+        <attr name="android:textColor" tools:ignore="ResourceName" />
+        <attr name="android:textSize" tools:ignore="ResourceName" />
     </declare-styleable>
 </resources>


### PR DESCRIPTION
migrate `textColor` and `textSize` to use `android:` namespace

fixes #10