### PR TITLE
Measurement optimizations and remeasure after animation completes

### DIFF
--- a/ticker/src/main/java/com/robinhood/ticker/TickerColumn.java
+++ b/ticker/src/main/java/com/robinhood/ticker/TickerColumn.java
@@ -118,6 +118,10 @@ class TickerColumn {
         endIndex = characterIndicesMap.get(targetChar);
     }
 
+    void onAnimationEnd() {
+        minimumRequiredWidth = currentWidth;
+    }
+
     void setAnimationProgress(float animationProgress) {
         if (animationProgress == 1f) {
             // Animation finished (or never started), set to stable state.

--- a/ticker/src/main/java/com/robinhood/ticker/TickerColumnManager.java
+++ b/ticker/src/main/java/com/robinhood/ticker/TickerColumnManager.java
@@ -98,6 +98,13 @@ class TickerColumnManager {
         return true;
     }
 
+    void onAnimationEnd() {
+        for (int i = 0, size = tickerColumns.size(); i < size; i++) {
+            final TickerColumn column = tickerColumns.get(i);
+            column.onAnimationEnd();
+        }
+    }
+
     void setAnimationProgress(float animationProgress) {
         for (int i = 0, size = tickerColumns.size(); i < size; i++) {
             final TickerColumn column = tickerColumns.get(i);

--- a/ticker/src/main/java/com/robinhood/ticker/TickerView.java
+++ b/ticker/src/main/java/com/robinhood/ticker/TickerView.java
@@ -80,7 +80,7 @@ public class TickerView extends View {
     private long animationDurationInMillis;
     private Interpolator animationInterpolator;
     private int gravity;
-    private boolean animateMeasurementChanges;
+    private boolean animateMeasurementChange;
 
     public TickerView(Context context) {
         super(context);
@@ -116,7 +116,6 @@ public class TickerView extends View {
         int textColor = DEFAULT_TEXT_COLOR;
         float textSize = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_SP, DEFAULT_TEXT_SIZE,
                 res.getDisplayMetrics());
-        int animationDurationInMillis = DEFAULT_ANIMATION_DURATION;
         int gravity = DEFAULT_GRAVITY;
 
         // Set the view attributes from XML or from default values defined in this class
@@ -143,15 +142,16 @@ public class TickerView extends View {
         }
 
         // Custom set attributes on the view should override textAppearance if applicable.
-        animationDurationInMillis = arr.getInt(
-                R.styleable.ticker_TickerView_ticker_animationDuration, animationDurationInMillis);
         gravity = arr.getInt(R.styleable.ticker_TickerView_android_gravity, gravity);
         textColor = arr.getColor(R.styleable.ticker_TickerView_android_textColor, textColor);
         textSize = arr.getDimension(R.styleable.ticker_TickerView_android_textSize, textSize);
 
         // After we've fetched the correct values for the attributes, set them on the view
         animationInterpolator = DEFAULT_ANIMATION_INTERPOLATOR;
-        this.animationDurationInMillis = animationDurationInMillis;
+        this.animationDurationInMillis = arr.getInt(
+                R.styleable.ticker_TickerView_ticker_animationDuration, DEFAULT_ANIMATION_DURATION);
+        this.animateMeasurementChange = arr.getBoolean(
+                R.styleable.ticker_TickerView_ticker_animateMeasurementChange, false);
         this.gravity = gravity;
         setTextColor(textColor);
         setTextSize(textSize);
@@ -381,17 +381,17 @@ public class TickerView extends View {
      *
      * <p>This flag is disabled by default.
      *
-     * @param animateMeasurementChanges whether or not to animate measurement changes.
+     * @param animateMeasurementChange whether or not to animate measurement changes.
      */
-    public void setAnimateMeasurementChanges(boolean animateMeasurementChanges) {
-        this.animateMeasurementChanges = animateMeasurementChanges;
+    public void setAnimateMeasurementChange(boolean animateMeasurementChange) {
+        this.animateMeasurementChange = animateMeasurementChange;
     }
 
     /**
      * @return whether or not we are currently animating measurement changes.
      */
-    public boolean getAnimateMeasurementChanges() {
-        return animateMeasurementChanges;
+    public boolean getAnimateMeasurementChange() {
+        return animateMeasurementChange;
     }
 
 
@@ -413,7 +413,7 @@ public class TickerView extends View {
     }
 
     private int computeDesiredWidth() {
-        final int contentWidth = (int) (animateMeasurementChanges ?
+        final int contentWidth = (int) (animateMeasurementChange ?
                 columnManager.getCurrentWidth() : columnManager.getMinimumRequiredWidth());
         return contentWidth + getPaddingLeft() + getPaddingRight();
     }

--- a/ticker/src/main/java/com/robinhood/ticker/TickerView.java
+++ b/ticker/src/main/java/com/robinhood/ticker/TickerView.java
@@ -379,6 +379,9 @@ public class TickerView extends View {
      * the entering/exiting character might get truncated by the view's view bounds as the width
      * shrinks or expands.
      *
+     * <p>Warning: using this feature may degrade performance as it will force a re-measure and
+     * re-layout during each animation frame.
+     *
      * <p>This flag is disabled by default.
      *
      * @param animateMeasurementChange whether or not to animate measurement changes.

--- a/ticker/src/main/res/values/attrs.xml
+++ b/ticker/src/main/res/values/attrs.xml
@@ -2,6 +2,7 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <declare-styleable name="ticker_TickerView">
         <attr name="ticker_animationDuration" format="reference|integer" />
+        <attr name="ticker_animateMeasurementChange" format="reference|boolean" />
 
         <!-- Custom implementations of common android text attributes -->
         <attr name="android:gravity" tools:ignore="ResourceName" />


### PR DESCRIPTION
- Do not call `requestLayout` when the content measurement do not affect the view's measurement (e.g. when the measurements are `EXACTLY`).
- Set the desired with to the target width once the animation completes.
- Force re-layout after animation completes so that the width/height matches the displayed text.

Closes #15 
