### PR TITLE
Implement Levenshtein distance algorithm to compute min edit distance

### DIFF
--- a/ticker-sample/src/main/java/com/robinhood/ticker/sample/MainActivity.java
+++ b/ticker-sample/src/main/java/com/robinhood/ticker/sample/MainActivity.java
@@ -55,7 +55,8 @@ public class MainActivity extends BaseActivity {
         final int digits = RANDOM.nextInt(2) + 6;
 
         ticker1.setText(getRandomNumber(digits));
-        ticker2.setText("$" + Float.toString(RANDOM.nextFloat() * 100).substring(0, digits));
+        final String currencyFloat = Float.toString(RANDOM.nextFloat() * 100);
+        ticker2.setText("$" + currencyFloat.substring(0, Math.min(digits, currencyFloat.length())));
         ticker3.setText(generateChars(RANDOM, alphabetlist, digits));
     }
 

--- a/ticker-sample/src/main/java/com/robinhood/ticker/sample/MainActivity.java
+++ b/ticker-sample/src/main/java/com/robinhood/ticker/sample/MainActivity.java
@@ -55,7 +55,7 @@ public class MainActivity extends BaseActivity {
         final int digits = RANDOM.nextInt(2) + 6;
 
         ticker1.setText(getRandomNumber(digits));
-        ticker2.setText("$" + Float.toString(RANDOM.nextFloat()).substring(0, digits));
+        ticker2.setText("$" + Float.toString(RANDOM.nextFloat() * 100).substring(0, digits));
         ticker3.setText(generateChars(RANDOM, alphabetlist, digits));
     }
 

--- a/ticker/src/main/java/com/robinhood/ticker/LevenshteinUtils.java
+++ b/ticker/src/main/java/com/robinhood/ticker/LevenshteinUtils.java
@@ -5,9 +5,9 @@ package com.robinhood.ticker;
  * https://en.wikipedia.org/wiki/Levenshtein_distance
  */
 public class LevenshteinUtils {
-    public static final int ACTION_SAME = 0;
-    public static final int ACTION_INSERT = 1;
-    public static final int ACTION_DELETE = 2;
+    static final int ACTION_SAME = 0;
+    static final int ACTION_INSERT = 1;
+    static final int ACTION_DELETE = 2;
 
     /**
      * Run a slightly modified version of Levenshtein distance algorithm to compute the minimum

--- a/ticker/src/main/java/com/robinhood/ticker/LevenshteinUtils.java
+++ b/ticker/src/main/java/com/robinhood/ticker/LevenshteinUtils.java
@@ -1,0 +1,101 @@
+package com.robinhood.ticker;
+
+/**
+ * Helper class to compute the Levenshtein distance between two strings.
+ * https://en.wikipedia.org/wiki/Levenshtein_distance
+ */
+public class LevenshteinUtils {
+    public static final int ACTION_SAME = 0;
+    public static final int ACTION_INSERT = 1;
+    public static final int ACTION_DELETE = 2;
+
+    /**
+     * Run a slightly modified version of Levenshtein distance algorithm to compute the minimum
+     * edit distance between the current and the target text. Unlike the traditional algorithm,
+     * we force return all {@link #ACTION_SAME} for inputs that are the same length (so optimize
+     * update over insertion/deletion).
+     *
+     * @param source the source character array
+     * @param target the target character array
+     * @return an int array of size min(source.length, target.length) where each index
+     *         corresponds to one of {@link #ACTION_SAME}, {@link #ACTION_INSERT},
+     *         {@link #ACTION_DELETE} to represent if we update, insert, or delete a character
+     *         at the particular index.
+     */
+    public static int[] computeColumnActions(char[] source, char[] target) {
+        final int sourceLength = source.length;
+        final int targetLength = target.length;
+        final int resultLength = Math.max(sourceLength, targetLength);
+
+        final int[] result = new int[resultLength];
+
+        if (sourceLength == targetLength) {
+            // No modifications needed if the length of the strings are the same
+            return result;
+        }
+
+        final int numRows = sourceLength + 1;
+        final int numCols = targetLength + 1;
+
+        // Compute the Levenshtein matrix
+        final int[][] matrix = new int[numRows][numCols];
+
+        for (int i = 0; i < numRows; i++) {
+            matrix[i][0] = i;
+        }
+        for (int j = 0; j < numCols; j++) {
+            matrix[0][j] = j;
+        }
+
+        int cost;
+        for (int j = 1; j < numCols; j++) {
+            for (int i = 1; i < numRows; i++) {
+                cost = source[i-1] == target[j-1] ? 0 : 1;
+
+                matrix[i][j] = min(
+                        matrix[i-1][j] + 1,
+                        matrix[i][j-1] + 1,
+                        matrix[i-1][j-1] + cost);
+            }
+        }
+
+        // Reverse trace the matrix to compute the necessary actions
+        int i = numRows - 1;
+        int j = numCols - 1;
+        int resultIndex = resultLength - 1;
+        while (resultIndex >= 0) {
+            if (i == 0) {
+                // At the top row, can only move left, meaning insert column
+                result[resultIndex] = ACTION_INSERT;
+                j--;
+            } else if (j == 0) {
+                // At the left column, can only move up, meaning delete column
+                result[resultIndex] = ACTION_DELETE;
+                i--;
+            } else {
+                final int top = matrix[i-1][j];
+                final int left = matrix[i][j-1];
+                final int topLeft = matrix[i-1][j-1];
+
+                if (topLeft <= top && topLeft <= left) {
+                    result[resultIndex] = ACTION_SAME;
+                    i--;
+                    j--;
+                } else if (top <= left) {
+                    result[resultIndex] = ACTION_DELETE;
+                    i--;
+                } else {
+                    result[resultIndex] = ACTION_INSERT;
+                    j--;
+                }
+            }
+            resultIndex--;
+        }
+
+        return result;
+    }
+
+    private static int min(int first, int second, int third) {
+        return Math.min(first, Math.min(second, third));
+    }
+}

--- a/ticker/src/main/java/com/robinhood/ticker/TickerColumn.java
+++ b/ticker/src/main/java/com/robinhood/ticker/TickerColumn.java
@@ -91,6 +91,10 @@ class TickerColumn {
         currentBottomDelta = 0f;
     }
 
+    char getCurrentChar() {
+        return currentChar;
+    }
+
     char getTargetChar() {
         return targetChar;
     }

--- a/ticker/src/main/java/com/robinhood/ticker/TickerColumnManager.java
+++ b/ticker/src/main/java/com/robinhood/ticker/TickerColumnManager.java
@@ -20,7 +20,6 @@ import android.graphics.Canvas;
 import android.graphics.Paint;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -78,7 +77,7 @@ class TickerColumnManager {
     /**
      * Tell the column manager the new target text that it should display.
      */
-    boolean setText(char[] text, boolean animate) {
+    void setText(char[] text, boolean animate) {
         if (characterList == null) {
             throw new IllegalStateException("Need to call setCharacterList(char[]) first.");
         }
@@ -93,6 +92,7 @@ class TickerColumnManager {
             }
         }
 
+        // Use Levenshtein distance algorithm to figure out how to manipulate the columns
         final int[] actions = LevenshteinUtils.computeColumnActions(getCurrentText(), text);
         int columnIndex = 0;
         int textIndex = 0;
@@ -118,8 +118,6 @@ class TickerColumnManager {
                     throw new IllegalArgumentException("Unknown action: " + actions[i]);
             }
         }
-
-        return true;
     }
 
     void setAnimationProgress(float animationProgress) {
@@ -164,33 +162,6 @@ class TickerColumnManager {
             final TickerColumn column = tickerColumns.get(i);
             column.draw(canvas, textPaint);
             canvas.translate(column.getCurrentWidth(), 0f);
-        }
-    }
-
-    /**
-     * Ensure that the number of columns matches {@param targetSize}.
-     */
-    void ensureColumnSize(int targetSize) {
-        final int columnSize = tickerColumns.size();
-        if (targetSize > columnSize) {
-            insertColumnsUpTo(targetSize);
-        } else {
-            for (int i = 0; i < columnSize - targetSize; i++) {
-                tickerColumns.remove(tickerColumns.size() - 1);
-            }
-        }
-    }
-
-    /**
-     * Insert (if applicable) columns until the number of columns match {@param targetSize}.
-     */
-    void insertColumnsUpTo(int targetSize) {
-        final int currentSize = tickerColumns.size();
-        if (targetSize > currentSize) {
-            final int toInsert = targetSize - currentSize;
-            for (int i = 0; i < toInsert; i++) {
-                tickerColumns.add(new TickerColumn(characterList, characterIndicesMap, metrics));
-            }
         }
     }
 }

--- a/ticker/src/main/java/com/robinhood/ticker/TickerColumnManager.java
+++ b/ticker/src/main/java/com/robinhood/ticker/TickerColumnManager.java
@@ -77,7 +77,7 @@ class TickerColumnManager {
     /**
      * Tell the column manager the new target text that it should display.
      */
-    void setText(char[] text, boolean animate) {
+    void setText(char[] text) {
         if (characterList == null) {
             throw new IllegalStateException("Need to call setCharacterList(char[]) first.");
         }
@@ -107,12 +107,8 @@ class TickerColumnManager {
                     textIndex++;
                     break;
                 case LevenshteinUtils.ACTION_DELETE:
-                    if (animate) {
-                        tickerColumns.get(columnIndex).setTargetChar(TickerUtils.EMPTY_CHAR);
-                        columnIndex++;
-                    } else {
-                        tickerColumns.remove(columnIndex);
-                    }
+                    tickerColumns.get(columnIndex).setTargetChar(TickerUtils.EMPTY_CHAR);
+                    columnIndex++;
                     break;
                 default:
                     throw new IllegalArgumentException("Unknown action: " + actions[i]);

--- a/ticker/src/main/java/com/robinhood/ticker/TickerView.java
+++ b/ticker/src/main/java/com/robinhood/ticker/TickerView.java
@@ -226,7 +226,7 @@ public class TickerView extends View {
             return;
         }
 
-        columnManager.setText(targetText, animate);
+        columnManager.setText(targetText);
         columnManager.setAnimationProgress(animate ? 0f : 1f);
         setContentDescription(text);
         checkForRelayout();

--- a/ticker/src/test/java/com/robinhood/ticker/LevenshteinUtilsTest.java
+++ b/ticker/src/test/java/com/robinhood/ticker/LevenshteinUtilsTest.java
@@ -1,0 +1,54 @@
+package com.robinhood.ticker;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class LevenshteinUtilsTest {
+    @Test
+    public void test_insert1() {
+        runTest("1111", "11211", "00100");
+    }
+
+    @Test
+    public void test_insert2() {
+        runTest("123", "0213", "0010");
+    }
+
+    @Test
+    public void test_delete() {
+        runTest("11211", "1111", "00200");
+    }
+
+    @Test
+    public void test_equal() {
+        runTest("1234", "1234", "0000");
+    }
+
+    @Test
+    public void test_completelyDifferent() {
+        runTest("1234", "5678", "0000");
+    }
+
+    @Test
+    public void test_shift() {
+        runTest("1234", "2345", "0000");
+    }
+
+    @Test
+    public void test_currency1() {
+        runTest("$123.99", "$1223.98", "00010000");
+    }
+
+    private void runTest(String source, String target, String actions) {
+        final int[] result = LevenshteinUtils.computeColumnActions(
+                source.toCharArray(), target.toCharArray());
+
+        final StringBuilder resultActions = new StringBuilder(result.length);
+        for (int resultChar : result) {
+            resultActions.append(Integer.toString(resultChar));
+        }
+
+        assertEquals(actions, resultActions.toString());
+    }
+}

--- a/ticker/src/test/java/com/robinhood/ticker/TickerColumnManagerTest.java
+++ b/ticker/src/test/java/com/robinhood/ticker/TickerColumnManagerTest.java
@@ -8,7 +8,8 @@ import org.mockito.MockitoAnnotations;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
+import static org.mockito.Matchers.anyChar;
+import static org.mockito.Mockito.when;
 
 public class TickerColumnManagerTest {
     @Mock TickerDrawMetrics metrics;
@@ -19,30 +20,11 @@ public class TickerColumnManagerTest {
     public void setup() {
         MockitoAnnotations.initMocks(this);
 
+        when(metrics.getCharWidth(anyChar())).thenReturn(5f);
+        when(metrics.getCharWidth(TickerUtils.EMPTY_CHAR)).thenReturn(0f);
+
         tickerColumnManager = new TickerColumnManager(metrics);
         tickerColumnManager.setCharacterList((TickerUtils.EMPTY_CHAR + "1234567890").toCharArray());
-    }
-
-    @Test
-    public void test_insertColumnsUpTo() {
-        assertEquals(0, numberOfTickerColumns());
-        tickerColumnManager.insertColumnsUpTo(2);
-        assertEquals(2, numberOfTickerColumns());
-        tickerColumnManager.insertColumnsUpTo(5);
-        assertEquals(5, numberOfTickerColumns());
-        tickerColumnManager.insertColumnsUpTo(1);
-        assertEquals(5, numberOfTickerColumns());
-    }
-
-    @Test
-    public void test_ensureColumnSize() {
-        assertEquals(0, numberOfTickerColumns());
-        tickerColumnManager.ensureColumnSize(2);
-        assertEquals(2, numberOfTickerColumns());
-        tickerColumnManager.ensureColumnSize(5);
-        assertEquals(5, numberOfTickerColumns());
-        tickerColumnManager.ensureColumnSize(1);
-        assertEquals(1, numberOfTickerColumns());
     }
 
     @Test
@@ -50,6 +32,7 @@ public class TickerColumnManagerTest {
         assertEquals(0, numberOfTickerColumns());
 
         tickerColumnManager.setText("1234".toCharArray(), true);
+        tickerColumnManager.setAnimationProgress(1f);
         assertEquals(4, numberOfTickerColumns());
         assertEquals('1', tickerColumnAtIndex(0).getTargetChar());
         assertEquals('2', tickerColumnAtIndex(1).getTargetChar());
@@ -58,10 +41,17 @@ public class TickerColumnManagerTest {
 
         tickerColumnManager.setText("999".toCharArray(), true);
         assertEquals(4, numberOfTickerColumns());
-        assertEquals('9', tickerColumnAtIndex(0).getTargetChar());
+        assertEquals(TickerUtils.EMPTY_CHAR, tickerColumnAtIndex(0).getTargetChar());
         assertEquals('9', tickerColumnAtIndex(1).getTargetChar());
         assertEquals('9', tickerColumnAtIndex(2).getTargetChar());
-        assertEquals(TickerUtils.EMPTY_CHAR, tickerColumnAtIndex(3).getTargetChar());
+        assertEquals('9', tickerColumnAtIndex(3).getTargetChar());
+
+        tickerColumnManager.setAnimationProgress(1f);
+        tickerColumnManager.setText("899".toCharArray(), true);
+        assertEquals(3, numberOfTickerColumns());
+        assertEquals('8', tickerColumnAtIndex(0).getTargetChar());
+        assertEquals('9', tickerColumnAtIndex(1).getTargetChar());
+        assertEquals('9', tickerColumnAtIndex(2).getTargetChar());
     }
 
     @Test

--- a/ticker/src/test/java/com/robinhood/ticker/TickerColumnManagerTest.java
+++ b/ticker/src/test/java/com/robinhood/ticker/TickerColumnManagerTest.java
@@ -31,7 +31,7 @@ public class TickerColumnManagerTest {
     public void test_setText_animate() {
         assertEquals(0, numberOfTickerColumns());
 
-        tickerColumnManager.setText("1234".toCharArray(), true);
+        tickerColumnManager.setText("1234".toCharArray());
         tickerColumnManager.setAnimationProgress(1f);
         assertEquals(4, numberOfTickerColumns());
         assertEquals('1', tickerColumnAtIndex(0).getTargetChar());
@@ -39,7 +39,7 @@ public class TickerColumnManagerTest {
         assertEquals('3', tickerColumnAtIndex(2).getTargetChar());
         assertEquals('4', tickerColumnAtIndex(3).getTargetChar());
 
-        tickerColumnManager.setText("999".toCharArray(), true);
+        tickerColumnManager.setText("999".toCharArray());
         assertEquals(4, numberOfTickerColumns());
         assertEquals(TickerUtils.EMPTY_CHAR, tickerColumnAtIndex(0).getTargetChar());
         assertEquals('9', tickerColumnAtIndex(1).getTargetChar());
@@ -47,7 +47,7 @@ public class TickerColumnManagerTest {
         assertEquals('9', tickerColumnAtIndex(3).getTargetChar());
 
         tickerColumnManager.setAnimationProgress(1f);
-        tickerColumnManager.setText("899".toCharArray(), true);
+        tickerColumnManager.setText("899".toCharArray());
         assertEquals(3, numberOfTickerColumns());
         assertEquals('8', tickerColumnAtIndex(0).getTargetChar());
         assertEquals('9', tickerColumnAtIndex(1).getTargetChar());
@@ -58,14 +58,14 @@ public class TickerColumnManagerTest {
     public void test_setText_noAnimate() {
         assertEquals(0, numberOfTickerColumns());
 
-        tickerColumnManager.setText("1234".toCharArray(), false);
+        tickerColumnManager.setText("1234".toCharArray());
         assertEquals(4, numberOfTickerColumns());
         assertEquals('1', tickerColumnAtIndex(0).getTargetChar());
         assertEquals('2', tickerColumnAtIndex(1).getTargetChar());
         assertEquals('3', tickerColumnAtIndex(2).getTargetChar());
         assertEquals('4', tickerColumnAtIndex(3).getTargetChar());
 
-        tickerColumnManager.setText("999".toCharArray(), false);
+        tickerColumnManager.setText("999".toCharArray());
         assertEquals(3, numberOfTickerColumns());
         assertEquals('9', tickerColumnAtIndex(0).getTargetChar());
         assertEquals('9', tickerColumnAtIndex(1).getTargetChar());
@@ -74,7 +74,7 @@ public class TickerColumnManagerTest {
 
     @Test
     public void test_shouldDebounce() {
-        tickerColumnManager.setText("1234".toCharArray(), false);
+        tickerColumnManager.setText("1234".toCharArray());
         assertTrue(tickerColumnManager.shouldDebounceText("1234".toCharArray()));
         assertFalse(tickerColumnManager.shouldDebounceText("12345".toCharArray()));
     }


### PR DESCRIPTION
Implement a modified version of Levenshtein distance algorithm (https://en.wikipedia.org/wiki/Levenshtein_distance) to compute how we should transition from one string to the next. This algorithm will allow us to make the minimum number of column changes for when the length of the text changes.

A side effect of this behavior is it will preserve the common elements in the string, e.g. for currency formats animating from $1234.55 to $234.76 will be much smoother.