### PR TITLE
Fix setText when we are not animating the text

### DIFF
--- a/ticker/src/main/java/com/robinhood/ticker/TickerView.java
+++ b/ticker/src/main/java/com/robinhood/ticker/TickerView.java
@@ -262,7 +262,6 @@ public class TickerView extends View {
 
         columnManager.setText(targetText);
         setContentDescription(text);
-        checkForRelayout();
 
         if (animate) {
             // Kick off the animator that draws the transition
@@ -276,6 +275,7 @@ public class TickerView extends View {
         } else {
             columnManager.setAnimationProgress(1f);
             columnManager.onAnimationEnd();
+            checkForRelayout();
             invalidate();
         }
     }


### PR DESCRIPTION
Previously when we call `setText` with animate=false, we were calling `checkForRelayout` before setting the animation progress to complete. This resulted in mis-measurement of the width for the view.