### PR TITLE
Fix checkForRelayout to not depend on measure mode

### DIFF
--- a/ticker/src/main/java/com/robinhood/ticker/TickerView.java
+++ b/ticker/src/main/java/com/robinhood/ticker/TickerView.java
@@ -72,7 +72,7 @@ public class TickerView extends View {
     // Minor optimizations for re-positioning the canvas for the composer.
     private final Rect viewBounds = new Rect();
 
-    private boolean widthAffectedByContent, heightAffectedByContent;
+    private int lastMeasuredDesiredWidth, lastMeasuredDesiredHeight;
 
     // View attributes, defaults are set in init().
     private float textSize;
@@ -430,9 +430,8 @@ public class TickerView extends View {
      * we set for the previous view state.
      */
     private void checkForRelayout() {
-        final boolean widthChanged = widthAffectedByContent && getWidth() != computeDesiredWidth();
-        final boolean heightChanged = heightAffectedByContent
-                && getHeight() != computeDesiredHeight();
+        final boolean widthChanged = lastMeasuredDesiredWidth != computeDesiredWidth();
+        final boolean heightChanged = lastMeasuredDesiredHeight != computeDesiredHeight();
 
         if (widthChanged || heightChanged) {
             requestLayout();
@@ -465,31 +464,28 @@ public class TickerView extends View {
         int desiredWidth = MeasureSpec.getSize(widthMeasureSpec);
         int desiredHeight = MeasureSpec.getSize(heightMeasureSpec);
 
+        lastMeasuredDesiredWidth = computeDesiredWidth();
+        lastMeasuredDesiredHeight = computeDesiredHeight();
+
         switch (widthMode) {
             case MeasureSpec.EXACTLY:
-                widthAffectedByContent = false;
                 break;
             case MeasureSpec.AT_MOST:
-                widthAffectedByContent = true;
-                desiredWidth = Math.min(desiredWidth, computeDesiredWidth());
+                desiredWidth = Math.min(desiredWidth, lastMeasuredDesiredWidth);
                 break;
             case MeasureSpec.UNSPECIFIED:
-                widthAffectedByContent = true;
-                desiredWidth = computeDesiredWidth();
+                desiredWidth = lastMeasuredDesiredWidth;
                 break;
         }
 
         switch (heightMode) {
             case MeasureSpec.EXACTLY:
-                heightAffectedByContent = false;
                 break;
             case MeasureSpec.AT_MOST:
-                heightAffectedByContent = true;
-                desiredHeight = Math.min(desiredHeight, computeDesiredHeight());
+                desiredHeight = Math.min(desiredHeight, lastMeasuredDesiredHeight);
                 break;
             case MeasureSpec.UNSPECIFIED:
-                heightAffectedByContent = true;
-                desiredHeight = computeDesiredHeight();
+                desiredHeight = lastMeasuredDesiredHeight;
                 break;
         }
 


### PR DESCRIPTION
The problem with using `MeasureSpec.mode` is that it will eventually converge to `EXACTLY` as we set custom measurements (even with calling `super.onMeasure` with the provided measure mode). Once it converges to `EXACTLY`, the width and height will never change until the parent view forces the child to remeasure itself.

Rather than keeping the boolean flags, let's just keep the last measured desiredWidth and desiredHeight so we can use those to check for relayout. This will bypass the problem of the view's width always greater than the desired width (e.g. `match_parent`) and unnecessarily forcing `requestLayout` on every animation.