### PR TITLE
[refactor] Refactor ticker to allow for variable number of character lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Getting started
 Add the ticker dependency to your `build.gradle`.
 
 ```groovy
-compile 'com.robinhood.ticker:ticker:1.2.2'
+implementation 'com.robinhood.ticker:ticker:1.2.2'
 ```
 
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip

--- a/ticker-sample/build.gradle
+++ b/ticker-sample/build.gradle
@@ -16,7 +16,4 @@ dependencies {
 
     implementation 'com.android.support:appcompat-v7:26.1.0'
     implementation 'com.android.support:recyclerview-v7:26.1.0'
-
-    implementation 'io.reactivex:rxjava:1.3.0'
-    implementation 'io.reactivex:rxandroid:1.2.1'
 }

--- a/ticker-sample/build.gradle
+++ b/ticker-sample/build.gradle
@@ -1,19 +1,19 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 26
+    compileSdkVersion 27
     buildToolsVersion '26.0.2'
 
     defaultConfig {
         applicationId "com.robinhood.ticker.sample"
         minSdkVersion 14
-        targetSdkVersion 26
+        targetSdkVersion 27
     }
 }
 
 dependencies {
     implementation project(':ticker')
 
-    implementation 'com.android.support:appcompat-v7:26.1.0'
-    implementation 'com.android.support:recyclerview-v7:26.1.0'
+    implementation 'com.android.support:appcompat-v7:27.0.2'
+    implementation 'com.android.support:recyclerview-v7:27.0.2'
 }

--- a/ticker-sample/src/main/java/com/robinhood/ticker/sample/MainActivity.java
+++ b/ticker-sample/src/main/java/com/robinhood/ticker/sample/MainActivity.java
@@ -10,7 +10,7 @@ import com.robinhood.ticker.TickerView;
 import java.util.Random;
 
 public class MainActivity extends BaseActivity {
-    private final char[] alphabetlist = TickerUtils.provideAlphabeticalList();
+    private final String alphabetlist = TickerUtils.provideAlphabeticalList();
 
     private TickerView ticker1, ticker2, ticker3;
 
@@ -41,10 +41,10 @@ public class MainActivity extends BaseActivity {
         ticker3.setText(generateChars(RANDOM, alphabetlist, digits));
     }
 
-    private String generateChars(Random random, char[] list, int numDigits) {
+    private String generateChars(Random random, String list, int numDigits) {
         final char[] result = new char[numDigits];
         for (int i = 0; i < numDigits; i++) {
-            result[i] = list[random.nextInt(list.length)];
+            result[i] = list.charAt(random.nextInt(list.length()));
         }
         return new String(result);
     }

--- a/ticker-sample/src/main/java/com/robinhood/ticker/sample/MainActivity.java
+++ b/ticker-sample/src/main/java/com/robinhood/ticker/sample/MainActivity.java
@@ -10,7 +10,7 @@ import com.robinhood.ticker.TickerView;
 import java.util.Random;
 
 public class MainActivity extends BaseActivity {
-    private char[] alphabetlist;
+    private final char[] alphabetlist = TickerUtils.provideAlphabeticalList();
 
     private TickerView ticker1, ticker2, ticker3;
 
@@ -19,21 +19,9 @@ public class MainActivity extends BaseActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
 
-        alphabetlist = new char[53];
-        alphabetlist[0] = TickerUtils.EMPTY_CHAR;
-        for (int i = 0; i < 2; i++) {
-            for (int j = 0; j < 26; j++) {
-                // Add all lowercase characters first, then add the uppercase characters.
-                alphabetlist[1 + i * 26 + j] = (char) ((i == 0) ? j + 97 : j + 65);
-            }
-        }
-
         ticker1 = findViewById(R.id.ticker1);
         ticker2 = findViewById(R.id.ticker2);
         ticker3 = findViewById(R.id.ticker3);
-
-        ticker2.setCharacterList(TickerUtils.getDefaultListForUSCurrency());
-        ticker3.setCharacterList(alphabetlist);
 
         findViewById(R.id.perfBtn).setOnClickListener(new View.OnClickListener() {
             @Override

--- a/ticker-sample/src/main/java/com/robinhood/ticker/sample/PerfActivity.java
+++ b/ticker-sample/src/main/java/com/robinhood/ticker/sample/PerfActivity.java
@@ -8,15 +8,12 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
-import com.robinhood.ticker.TickerUtils;
 import com.robinhood.ticker.TickerView;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public class PerfActivity extends BaseActivity {
-    private static final char[] CHAR_LIST = TickerUtils.getDefaultNumberList();
-
     private final List<TickerViewHolder> boundViewHolders = new ArrayList<>();
 
     @Override
@@ -70,11 +67,6 @@ public class PerfActivity extends BaseActivity {
             ticker2 = itemView.findViewById(R.id.ticker2);
             ticker3 = itemView.findViewById(R.id.ticker3);
             ticker4 = itemView.findViewById(R.id.ticker4);
-
-            ticker1.setCharacterList(CHAR_LIST);
-            ticker2.setCharacterList(CHAR_LIST);
-            ticker3.setCharacterList(CHAR_LIST);
-            ticker4.setCharacterList(CHAR_LIST);
         }
 
         void update(boolean animate) {

--- a/ticker-sample/src/main/res/layout/activity_main.xml
+++ b/ticker-sample/src/main/res/layout/activity_main.xml
@@ -31,6 +31,7 @@
         android:textAppearance="@style/TickerTextAppearance"
         android:textStyle="bold"
         app:ticker_animationDuration="500"
+        app:ticker_defaultCharacterList="number"
         tools:text="$123.45" />
 
     <com.robinhood.ticker.TickerView
@@ -40,7 +41,8 @@
         android:gravity="center"
         android:padding="@dimen/activity_vertical_margin"
         android:textAppearance="@style/TickerTextAppearance"
-        app:ticker_animationDuration="500" />
+        app:ticker_animationDuration="500"
+        app:ticker_defaultCharacterList="alphabet" />
 
     <Button
         android:id="@+id/perfBtn"

--- a/ticker-sample/src/main/res/layout/row_perf.xml
+++ b/ticker-sample/src/main/res/layout/row_perf.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="horizontal">
@@ -9,27 +10,31 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_weight="1"
-        android:gravity="center" />
+        android:gravity="center"
+        app:ticker_defaultCharacterList="number" />
 
     <com.robinhood.ticker.TickerView
         android:id="@+id/ticker2"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_weight="1"
-        android:gravity="center" />
+        android:gravity="center"
+        app:ticker_defaultCharacterList="number" />
 
     <com.robinhood.ticker.TickerView
         android:id="@+id/ticker3"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_weight="1"
-        android:gravity="center" />
+        android:gravity="center"
+        app:ticker_defaultCharacterList="number" />
 
     <com.robinhood.ticker.TickerView
         android:id="@+id/ticker4"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_weight="1"
-        android:gravity="center" />
+        android:gravity="center"
+        app:ticker_defaultCharacterList="number" />
 
 </LinearLayout>

--- a/ticker-sample/src/main/res/values/colors.xml
+++ b/ticker-sample/src/main/res/values/colors.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="colorPrimary">#3F51B5</color>
-    <color name="colorPrimaryDark">#303F9F</color>
-    <color name="colorAccent">#FF4081</color>
+    <color name="colorPrimary">#21ce99</color>
+    <color name="colorPrimaryDark">#26a47b</color>
+    <color name="colorAccent">#21ce99</color>
 </resources>

--- a/ticker-sample/src/main/res/values/strings.xml
+++ b/ticker-sample/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
 <resources>
-    <string name="app_name">ticker-sample</string>
+    <string name="app_name">Ticker Example</string>
     <string name="perf_test">Perf test</string>
 </resources>

--- a/ticker/build.gradle
+++ b/ticker/build.gradle
@@ -14,7 +14,7 @@ android {
 
 dependencies {
     testImplementation 'junit:junit:4.12'
-    testImplementation 'org.mockito:mockito-core:2.10.0'
+    testImplementation 'org.mockito:mockito-core:2.12.0'
 }
 
 apply from: './gradle-mvn-push.gradle'

--- a/ticker/build.gradle
+++ b/ticker/build.gradle
@@ -14,7 +14,7 @@ android {
 
 dependencies {
     testImplementation 'junit:junit:4.12'
-    testImplementation 'org.mockito:mockito-core:2.12.0'
+    testImplementation 'org.mockito:mockito-core:2.13.0'
 }
 
 apply from: './gradle-mvn-push.gradle'

--- a/ticker/src/main/java/com/robinhood/ticker/LevenshteinUtils.java
+++ b/ticker/src/main/java/com/robinhood/ticker/LevenshteinUtils.java
@@ -1,7 +1,25 @@
+/*
+  Copyright (C) 2016 Robinhood Markets, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
 package com.robinhood.ticker;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Helper class to compute the Levenshtein distance between two strings.
@@ -13,25 +31,123 @@ public class LevenshteinUtils {
     static final int ACTION_DELETE = 2;
 
     /**
+     * This is a wrapper function around {@link #computeColumnActionsForSegment} that
+     * additionally takes in supportedCharacters. It uses supportedCharacters to compute whether
+     * the current character should be animated or if it should remain in-place.
+     *
+     * For specific implementation details, see {@link #computeColumnActionsForSegment}.
+     *
+     * @param supportedCharacters all characters that support custom animation.
+     */
+    public static int[] computeColumnActions(char[] source, char[] target,
+            Set<Character> supportedCharacters) {
+        int sourceIndex = 0;
+        int targetIndex = 0;
+
+        List<int[]> columnActions = new ArrayList<>();
+        int totalNumActions = 0;
+        while (true) {
+            // Check for terminating conditions
+            final boolean reachedEndOfSource = sourceIndex == source.length;
+            final boolean reachedEndOfTarget = targetIndex == target.length;
+            if (reachedEndOfSource && reachedEndOfTarget) {
+                break;
+            } else if (reachedEndOfSource) {
+                final int[] remainingActions = new int[target.length - targetIndex];
+                Arrays.fill(remainingActions, ACTION_INSERT);
+                columnActions.add(remainingActions);
+                totalNumActions += remainingActions.length;
+                break;
+            } else if (reachedEndOfTarget) {
+                final int[] remainingActions = new int[source.length - sourceIndex];
+                Arrays.fill(remainingActions, ACTION_DELETE);
+                columnActions.add(remainingActions);
+                totalNumActions += remainingActions.length;
+                break;
+            }
+
+            final boolean containsSourceChar = supportedCharacters.contains(source[sourceIndex]);
+            final boolean containsTargetChar = supportedCharacters.contains(target[targetIndex]);
+
+            if (containsSourceChar && containsTargetChar) {
+                // We reached a segment that we can perform animations on
+                final int sourceEndIndex =
+                        findNextUnsupportedChar(source, sourceIndex + 1, supportedCharacters);
+                final int targetEndIndex =
+                        findNextUnsupportedChar(target, targetIndex + 1, supportedCharacters);
+                final int[] columnActionsForSegment = computeColumnActionsForSegment(
+                        source, target, sourceIndex, sourceEndIndex, targetIndex, targetEndIndex
+                );
+                columnActions.add(columnActionsForSegment);
+                totalNumActions += columnActionsForSegment.length;
+                sourceIndex = sourceEndIndex;
+                targetIndex = targetEndIndex;
+            } else if (containsSourceChar) {
+                // We are animating in a target character that isn't supported
+                columnActions.add(new int[] { ACTION_INSERT });
+                totalNumActions++;
+                targetIndex++;
+            } else if (containsTargetChar) {
+                // We are animating out a source character that isn't supported
+                columnActions.add(new int[] { ACTION_DELETE });
+                totalNumActions++;
+                sourceIndex++;
+            } else {
+                // Both characters are not supported, perform default animation to replace
+                columnActions.add(new int[] { ACTION_SAME });
+                totalNumActions++;
+                sourceIndex++;
+                targetIndex++;
+            }
+        }
+
+        // Concat all of the actions into one array
+        final int[] result = new int[totalNumActions];
+        int index = 0;
+        for (int[] actions : columnActions) {
+            System.arraycopy(actions, 0, result, index, actions.length);
+            index += actions.length;
+        }
+        return result;
+    }
+
+    private static int findNextUnsupportedChar(char[] chars, int startIndex,
+            Set<Character> supportedCharacters) {
+        while (startIndex < chars.length) {
+            if (!supportedCharacters.contains(chars[startIndex])) {
+                break;
+            }
+            startIndex++;
+        }
+        return startIndex;
+    }
+
+    /**
      * Run a slightly modified version of Levenshtein distance algorithm to compute the minimum
-     * edit distance between the current and the target text. Unlike the traditional algorithm,
-     * we force return all {@link #ACTION_SAME} for inputs that are the same length (so optimize
-     * update over insertion/deletion).
+     * edit distance between the current and the target text within the start and end bounds.
+     * Unlike the traditional algorithm, we force return all {@link #ACTION_SAME} for inputs that
+     * are the same length (so optimize update over insertion/deletion).
      *
      * @param source the source character array
      * @param target the target character array
+     * @param sourceStart the start index of source to compute column actions (inclusive)
+     * @param sourceEnd the end index of source to compute column actions (exclusive)
+     * @param targetStart the start index of target to compute column actions (inclusive)
+     * @param targetEnd the end index of target to compute column actions (exclusive)
      * @return an int array of size min(source.length, target.length) where each index
      *         corresponds to one of {@link #ACTION_SAME}, {@link #ACTION_INSERT},
      *         {@link #ACTION_DELETE} to represent if we update, insert, or delete a character
      *         at the particular index.
      */
-    public static int[] computeColumnActions(char[] source, char[] target) {
-        final int sourceLength = source.length;
-        final int targetLength = target.length;
+    private static int[] computeColumnActionsForSegment(char[] source, char[] target,
+            int sourceStart, int sourceEnd, int targetStart, int targetEnd) {
+        final int sourceLength = sourceEnd - sourceStart;
+        final int targetLength = targetEnd - targetStart;
         final int resultLength = Math.max(sourceLength, targetLength);
 
         if (sourceLength == targetLength) {
             // No modifications needed if the length of the strings are the same
+            // NOTE: this assumes that ACTION_SAME has the value of 0!
             return new int[resultLength];
         }
 
@@ -49,14 +165,14 @@ public class LevenshteinUtils {
         }
 
         int cost;
-        for (int j = 1; j < numCols; j++) {
-            for (int i = 1; i < numRows; i++) {
-                cost = source[i-1] == target[j-1] ? 0 : 1;
+        for (int row = 1; row < numRows; row++) {
+            for (int col = 1; col < numCols; col++) {
+                cost = source[row - 1 + sourceStart] == target[col - 1 + targetStart] ? 0 : 1;
 
-                matrix[i][j] = min(
-                        matrix[i-1][j] + 1,
-                        matrix[i][j-1] + 1,
-                        matrix[i-1][j-1] + cost);
+                matrix[row][col] = min(
+                        matrix[row-1][col] + 1,
+                        matrix[row][col-1] + 1,
+                        matrix[row-1][col-1] + cost);
             }
         }
 

--- a/ticker/src/main/java/com/robinhood/ticker/TickerColumnManager.java
+++ b/ticker/src/main/java/com/robinhood/ticker/TickerColumnManager.java
@@ -51,13 +51,12 @@ class TickerColumnManager {
     /**
      * @inheritDoc TickerView#setCharacterLists
      */
-    void setCharacterLists(char[]... characterLists) {
+    void setCharacterLists(String... characterLists) {
         this.characterLists = new ArrayList<>(characterLists.length);
         this.supportedCharacters = new HashSet<>();
-        for (char[] characterList : characterLists) {
-            final char[] modifiedCharacterList = new char[characterList.length + 1];
-            modifiedCharacterList[0] = TickerUtils.EMPTY_CHAR;
-            System.arraycopy(characterList, 0, modifiedCharacterList, 1, characterList.length);
+        for (String characterList : characterLists) {
+            final char[] modifiedCharacterList =
+                    (TickerUtils.EMPTY_CHAR + characterList).toCharArray();
             this.characterLists.add(modifiedCharacterList);
 
             for (char c : modifiedCharacterList) {
@@ -99,8 +98,8 @@ class TickerColumnManager {
         );
         int columnIndex = 0;
         int textIndex = 0;
-        for (int action : actions) {
-            switch (action) {
+        for (int i = 0; i < actions.length; i++) {
+            switch (actions[i]) {
                 case LevenshteinUtils.ACTION_INSERT:
                     tickerColumns.add(columnIndex,
                             new TickerColumn(characterLists, characterIndicesMaps, metrics));
@@ -115,7 +114,7 @@ class TickerColumnManager {
                     columnIndex++;
                     break;
                 default:
-                    throw new IllegalArgumentException("Unknown action: " + action);
+                    throw new IllegalArgumentException("Unknown action: " + actions[i]);
             }
         }
     }

--- a/ticker/src/main/java/com/robinhood/ticker/TickerDrawMetrics.java
+++ b/ticker/src/main/java/com/robinhood/ticker/TickerDrawMetrics.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2016 Robinhood Markets, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ticker/src/main/java/com/robinhood/ticker/TickerUtils.java
+++ b/ticker/src/main/java/com/robinhood/ticker/TickerUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2016 Robinhood Markets, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,48 +23,13 @@ package com.robinhood.ticker;
  * @author Jin Cao, Robinhood
  */
 public class TickerUtils {
-    public static final char EMPTY_CHAR = (char) 0;
+    static final char EMPTY_CHAR = (char) 0;
 
-    /**
-     * @return a default ordering for all viewable ASCII characters. This list also special cases
-     *         space to be in front of the 0 and swap '.' with '/'. These special cases make
-     *         typical US currency animations intuitive.
-     */
-    public static char[] getDefaultListForUSCurrency() {
-        final int indexOf0 = (int) '0';
-        final int indexOfPeriod = (int) '.';
-        final int indexOfSlash = (int) '/';
-
-        final int start = 33;
-        final int end = 256;
-
-        final char[] charList = new char[end - start + 1];
-        for (int i = start; i < indexOf0; i++) {
-            charList[i - start] = (char) i;
-        }
-
-        // Special case EMPTY_CHAR and '.' <-> '/'
-        charList[indexOf0 - start] = EMPTY_CHAR;
-        charList[indexOfPeriod - start] = '/';
-        charList[indexOfSlash - start] = '.';
-
-        for (int i = indexOf0 + 1; i < end + 1; i++) {
-            charList[i - start] = (char) (i - 1);
-        }
-
-        return charList;
+    public static char[] provideNumberList() {
+        return "0123456789".toCharArray();
     }
 
-    /**
-     * @return a default ordering for numbers.
-     */
-    public static char[] getDefaultNumberList() {
-        final char[] charList = new char[12];
-        charList[0] = EMPTY_CHAR;
-        charList[1] = (int) '.';
-        for (int i = 0; i < 10; i++) {
-            charList[i + 2] = (char) (i + 48);
-        }
-        return charList;
+    public static char[] provideAlphabeticalList() {
+        return "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ".toCharArray();
     }
 }

--- a/ticker/src/main/java/com/robinhood/ticker/TickerUtils.java
+++ b/ticker/src/main/java/com/robinhood/ticker/TickerUtils.java
@@ -25,11 +25,11 @@ package com.robinhood.ticker;
 public class TickerUtils {
     static final char EMPTY_CHAR = (char) 0;
 
-    public static char[] provideNumberList() {
-        return "0123456789".toCharArray();
+    public static String provideNumberList() {
+        return "0123456789";
     }
 
-    public static char[] provideAlphabeticalList() {
-        return "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ".toCharArray();
+    public static String provideAlphabeticalList() {
+        return "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
     }
 }

--- a/ticker/src/main/java/com/robinhood/ticker/TickerView.java
+++ b/ticker/src/main/java/com/robinhood/ticker/TickerView.java
@@ -264,7 +264,7 @@ public class TickerView extends View {
      * @param text the text to display.
      */
     public void setText(String text) {
-        setText(text, this.text != null && !this.text.isEmpty());
+        setText(text, !TextUtils.isEmpty(this.text));
     }
 
     /**

--- a/ticker/src/main/java/com/robinhood/ticker/TickerView.java
+++ b/ticker/src/main/java/com/robinhood/ticker/TickerView.java
@@ -124,16 +124,16 @@ public class TickerView extends View {
         final StyledAttributes styledAttributes = new StyledAttributes(res);
 
         // Set the view attributes from XML or from default values defined in this class
-        final TypedArray arr = context.obtainStyledAttributes(attrs, R.styleable.ticker_TickerView,
+        final TypedArray arr = context.obtainStyledAttributes(attrs, R.styleable.TickerView,
                 defStyleAttr, defStyleRes);
 
         final int textAppearanceResId = arr.getResourceId(
-                R.styleable.ticker_TickerView_android_textAppearance, -1);
+                R.styleable.TickerView_android_textAppearance, -1);
 
         // Check textAppearance first
         if (textAppearanceResId != -1) {
             final TypedArray textAppearanceArr = context.obtainStyledAttributes(
-                    textAppearanceResId, R.styleable.ticker_TickerView);
+                    textAppearanceResId, R.styleable.TickerView);
             styledAttributes.applyTypedArray(textAppearanceArr);
             textAppearanceArr.recycle();
         }
@@ -144,9 +144,9 @@ public class TickerView extends View {
         // After we've fetched the correct values for the attributes, set them on the view
         animationInterpolator = DEFAULT_ANIMATION_INTERPOLATOR;
         this.animationDurationInMillis = arr.getInt(
-                R.styleable.ticker_TickerView_ticker_animationDuration, DEFAULT_ANIMATION_DURATION);
+                R.styleable.TickerView_ticker_animationDuration, DEFAULT_ANIMATION_DURATION);
         this.animateMeasurementChange = arr.getBoolean(
-                R.styleable.ticker_TickerView_ticker_animateMeasurementChange, false);
+                R.styleable.TickerView_ticker_animateMeasurementChange, false);
         this.gravity = styledAttributes.gravity;
 
         if (styledAttributes.shadowColor != 0) {
@@ -162,7 +162,7 @@ public class TickerView extends View {
         setTextSize(styledAttributes.textSize);
 
         final int defaultCharList =
-                arr.getInt(R.styleable.ticker_TickerView_ticker_defaultCharacterList, 0);
+                arr.getInt(R.styleable.TickerView_ticker_defaultCharacterList, 0);
         switch (defaultCharList) {
             case 1:
                 setCharacterLists(TickerUtils.provideNumberList());
@@ -217,17 +217,17 @@ public class TickerView extends View {
         }
 
         void applyTypedArray(TypedArray arr) {
-            gravity = arr.getInt(R.styleable.ticker_TickerView_android_gravity, gravity);
-            shadowColor = arr.getColor(R.styleable.ticker_TickerView_android_shadowColor,
+            gravity = arr.getInt(R.styleable.TickerView_android_gravity, gravity);
+            shadowColor = arr.getColor(R.styleable.TickerView_android_shadowColor,
                     shadowColor);
-            shadowDx = arr.getFloat(R.styleable.ticker_TickerView_android_shadowDx, shadowDx);
-            shadowDy = arr.getFloat(R.styleable.ticker_TickerView_android_shadowDy, shadowDy);
-            shadowRadius = arr.getFloat(R.styleable.ticker_TickerView_android_shadowRadius,
+            shadowDx = arr.getFloat(R.styleable.TickerView_android_shadowDx, shadowDx);
+            shadowDy = arr.getFloat(R.styleable.TickerView_android_shadowDy, shadowDy);
+            shadowRadius = arr.getFloat(R.styleable.TickerView_android_shadowRadius,
                     shadowRadius);
-            text = arr.getString(R.styleable.ticker_TickerView_android_text);
-            textColor = arr.getColor(R.styleable.ticker_TickerView_android_textColor, textColor);
-            textSize = arr.getDimension(R.styleable.ticker_TickerView_android_textSize, textSize);
-            textStyle = arr.getInt(R.styleable.ticker_TickerView_android_textStyle, textStyle);
+            text = arr.getString(R.styleable.TickerView_android_text);
+            textColor = arr.getColor(R.styleable.TickerView_android_textColor, textColor);
+            textSize = arr.getDimension(R.styleable.TickerView_android_textSize, textSize);
+            textStyle = arr.getInt(R.styleable.TickerView_android_textStyle, textStyle);
         }
     }
 

--- a/ticker/src/main/java/com/robinhood/ticker/TickerView.java
+++ b/ticker/src/main/java/com/robinhood/ticker/TickerView.java
@@ -1,17 +1,17 @@
-/**
- * Copyright (C) 2016 Robinhood Markets, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/*
+  Copyright (C) 2016 Robinhood Markets, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
  */
 
 package com.robinhood.ticker;
@@ -41,7 +41,7 @@ import android.view.animation.Interpolator;
 /**
  * The primary view for showing a ticker text view that handles smoothly scrolling from the
  * current text to a given text. The scrolling behavior is defined by
- * {@link #setCharacterList(char[])} which dictates what characters come in between the starting
+ * {@link #setCharacterLists} which dictates what characters come in between the starting
  * and ending characters.
  *
  * <p>This class primarily handles the drawing customization of the ticker view, for example
@@ -165,16 +165,17 @@ public class TickerView extends View {
                 arr.getInt(R.styleable.ticker_TickerView_ticker_defaultCharacterList, 0);
         switch (defaultCharList) {
             case 1:
-                setCharacterList(TickerUtils.getDefaultListForUSCurrency());
+                setCharacterLists(TickerUtils.provideNumberList());
                 break;
             case 2:
-                setCharacterList(TickerUtils.getDefaultNumberList());
+                setCharacterLists(TickerUtils.provideAlphabeticalList());
                 break;
             default:
                 if (isInEditMode()) {
-                    setCharacterList(TickerUtils.getDefaultListForUSCurrency());
+                    setCharacterLists(TickerUtils.provideNumberList());
                 }
         }
+
         setText(styledAttributes.text, false);
 
         arr.recycle();
@@ -243,28 +244,16 @@ public class TickerView extends View {
      * it will know that it has to go from 'd' to 'c' to 'b' to 'a', and these are the characters
      * that show up during the animation scroll.
      *
+     * <p>We allow for multiple character lists, and the character lists will be prioritized with
+     * latter lists given a higher priority than the previous lists. e.g. given [1,2,3] and [1,3],
+     * an animation from 1 to 3 will use the sequence [1,3] rather than [1,2,3].
+     *
      * <p>You can find some helpful character list generators in {@link TickerUtils}.
      *
-     * <p>Special note: the character list must contain {@link TickerUtils#EMPTY_CHAR} because the
-     * ticker needs to know how to animate from empty to another character (e.g. when the length
-     * of the string changes).
-     *
-     * @param characterList the character array that dictates character orderings.
+     * @param characterLists the list of character array that dictates character orderings.
      */
-    public void setCharacterList(char[] characterList) {
-        boolean foundEmpty = false;
-        for (char character : characterList) {
-            if (character == TickerUtils.EMPTY_CHAR) {
-                foundEmpty = true;
-                break;
-            }
-        }
-
-        if (!foundEmpty) {
-            throw new IllegalArgumentException("Missing TickerUtils#EMPTY_CHAR in character list");
-        }
-
-        columnManager.setCharacterList(characterList);
+    public void setCharacterLists(char[]... characterLists) {
+        columnManager.setCharacterLists(characterLists);
     }
 
     /**

--- a/ticker/src/main/java/com/robinhood/ticker/TickerView.java
+++ b/ticker/src/main/java/com/robinhood/ticker/TickerView.java
@@ -237,22 +237,22 @@ public class TickerView extends View {
 
     /**
      * This is the primary API that the view uses to determine how to animate from one character
-     * to another. The provided character array dictates what characters will appear between
+     * to another. The provided strings dictates what characters will appear between
      * the start and end characters.
      *
-     * <p>For example, given the list [a,b,c,d,e], if the view wants to animate from 'd' to 'a',
+     * <p>For example, given the string "abcde", if the view wants to animate from 'd' to 'a',
      * it will know that it has to go from 'd' to 'c' to 'b' to 'a', and these are the characters
      * that show up during the animation scroll.
      *
      * <p>We allow for multiple character lists, and the character lists will be prioritized with
-     * latter lists given a higher priority than the previous lists. e.g. given [1,2,3] and [1,3],
+     * latter lists given a higher priority than the previous lists. e.g. given "123" and "13",
      * an animation from 1 to 3 will use the sequence [1,3] rather than [1,2,3].
      *
      * <p>You can find some helpful character list generators in {@link TickerUtils}.
      *
-     * @param characterLists the list of character array that dictates character orderings.
+     * @param characterLists the list of strings that dictates character orderings.
      */
-    public void setCharacterLists(char[]... characterLists) {
+    public void setCharacterLists(String... characterLists) {
         columnManager.setCharacterLists(characterLists);
     }
 

--- a/ticker/src/main/java/com/robinhood/ticker/TickerView.java
+++ b/ticker/src/main/java/com/robinhood/ticker/TickerView.java
@@ -274,7 +274,7 @@ public class TickerView extends View {
      * @param text the text to display.
      * @param animate whether to animate to text.
      */
-    public synchronized void setText(String text, boolean animate) {
+    public void setText(String text, boolean animate) {
         if (TextUtils.equals(text, this.text)) {
             return;
         }

--- a/ticker/src/main/java/com/robinhood/ticker/TickerView.java
+++ b/ticker/src/main/java/com/robinhood/ticker/TickerView.java
@@ -517,35 +517,11 @@ public class TickerView extends View {
 
     @Override
     protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
-        final int widthMode = MeasureSpec.getMode(widthMeasureSpec);
-        final int heightMode = MeasureSpec.getMode(heightMeasureSpec);
-        int desiredWidth = MeasureSpec.getSize(widthMeasureSpec);
-        int desiredHeight = MeasureSpec.getSize(heightMeasureSpec);
-
         lastMeasuredDesiredWidth = computeDesiredWidth();
         lastMeasuredDesiredHeight = computeDesiredHeight();
 
-        switch (widthMode) {
-            case MeasureSpec.EXACTLY:
-                break;
-            case MeasureSpec.AT_MOST:
-                desiredWidth = Math.min(desiredWidth, lastMeasuredDesiredWidth);
-                break;
-            case MeasureSpec.UNSPECIFIED:
-                desiredWidth = lastMeasuredDesiredWidth;
-                break;
-        }
-
-        switch (heightMode) {
-            case MeasureSpec.EXACTLY:
-                break;
-            case MeasureSpec.AT_MOST:
-                desiredHeight = Math.min(desiredHeight, lastMeasuredDesiredHeight);
-                break;
-            case MeasureSpec.UNSPECIFIED:
-                desiredHeight = lastMeasuredDesiredHeight;
-                break;
-        }
+        int desiredWidth = resolveSize(lastMeasuredDesiredWidth, widthMeasureSpec);
+        int desiredHeight = resolveSize(lastMeasuredDesiredHeight, heightMeasureSpec);
 
         setMeasuredDimension(desiredWidth, desiredHeight);
     }

--- a/ticker/src/main/res/values/attrs.xml
+++ b/ticker/src/main/res/values/attrs.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <declare-styleable name="ticker_TickerView">
+    <declare-styleable name="TickerView">
         <attr name="ticker_animationDuration" format="reference|integer" />
         <attr name="ticker_animateMeasurementChange" format="reference|boolean" />
         <attr name="ticker_defaultCharacterList" format="enum">

--- a/ticker/src/main/res/values/attrs.xml
+++ b/ticker/src/main/res/values/attrs.xml
@@ -4,8 +4,8 @@
         <attr name="ticker_animationDuration" format="reference|integer" />
         <attr name="ticker_animateMeasurementChange" format="reference|boolean" />
         <attr name="ticker_defaultCharacterList" format="enum">
-            <enum name="us_currency" value="1" />
-            <enum name="number" value="2" />
+            <enum name="number" value="1" />
+            <enum name="alphabet" value="2" />
         </attr>
 
         <!-- Custom implementations of common android text attributes -->

--- a/ticker/src/test/java/com/robinhood/ticker/LevenshteinUtilsTest.java
+++ b/ticker/src/test/java/com/robinhood/ticker/LevenshteinUtilsTest.java
@@ -1,10 +1,24 @@
 package com.robinhood.ticker;
 
+import org.junit.Before;
 import org.junit.Test;
+
+import java.util.HashSet;
+import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 
 public class LevenshteinUtilsTest {
+    private Set<Character> numbers;
+
+    @Before
+    public void setup() {
+        numbers = new HashSet<>();
+        for (char c : "1234567890".toCharArray()) {
+            numbers.add(c);
+        }
+    }
+
     @Test
     public void test_insert1() {
         runTest("1111", "11211", "00100");
@@ -13,6 +27,11 @@ public class LevenshteinUtilsTest {
     @Test
     public void test_insert2() {
         runTest("123", "0213", "0010");
+    }
+
+    @Test
+    public void test_insert3() {
+        runTest("9", "10", "10");
     }
 
     @Test
@@ -49,19 +68,26 @@ public class LevenshteinUtilsTest {
     }
 
     @Test
-    public void test_currency1() {
+    public void test_computeWithUnsupportedChars1() {
         runTest("$123.99", "$1223.98", "00010000");
+    }
+
+    @Test
+    public void test_computeWithUnsupportedChars2() {
+        runTest("$1.0000", "$1000.0", "0011100222");
     }
 
     private void runTest(String source, String target, String actions) {
         final int[] result = LevenshteinUtils.computeColumnActions(
-                source.toCharArray(), target.toCharArray());
+                source.toCharArray(), target.toCharArray(), numbers);
+        assertEquals(actions, convertArrToString(result));
+    }
 
-        final StringBuilder resultActions = new StringBuilder(result.length);
-        for (int resultChar : result) {
-            resultActions.append(Integer.toString(resultChar));
+    private String convertArrToString(int[] arr) {
+        final StringBuilder result = new StringBuilder(arr.length);
+        for (int resultChar : arr) {
+            result.append(Integer.toString(resultChar));
         }
-
-        assertEquals(actions, resultActions.toString());
+        return result.toString();
     }
 }

--- a/ticker/src/test/java/com/robinhood/ticker/TickerColumnManagerTest.java
+++ b/ticker/src/test/java/com/robinhood/ticker/TickerColumnManagerTest.java
@@ -22,7 +22,7 @@ public class TickerColumnManagerTest {
         when(metrics.getCharWidth(TickerUtils.EMPTY_CHAR)).thenReturn(0f);
 
         tickerColumnManager = new TickerColumnManager(metrics);
-        tickerColumnManager.setCharacterList((TickerUtils.EMPTY_CHAR + "1234567890").toCharArray());
+        tickerColumnManager.setCharacterLists("1234567890".toCharArray());
     }
 
     @Test

--- a/ticker/src/test/java/com/robinhood/ticker/TickerColumnTest.java
+++ b/ticker/src/test/java/com/robinhood/ticker/TickerColumnTest.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -44,7 +45,11 @@ public class TickerColumnTest {
         when(metrics.getCharHeight()).thenReturn(CHAR_HEIGHT);
         when(metrics.getCharWidth(anyChar())).thenReturn(DEFAULT_CHAR_WIDTH);
         when(metrics.getCharWidth(TickerUtils.EMPTY_CHAR)).thenReturn(0f);
-        tickerColumn = new TickerColumn(charList, charMap, metrics);
+        tickerColumn = new TickerColumn(
+                Collections.singletonList(charList),
+                Collections.singletonList(charMap),
+                metrics
+        );
     }
 
     @Test


### PR DESCRIPTION
This is a backward incompatible change in preparation for major release 2.

Breaking changes:
- Changed possible values for `app:ticker_defaultCharacterList`
- Completely recreated TickerUtils with new methods
- Removed the need to include `TickerUtils.EMPTY_CHAR` in every character list.
- `setCharacterList` now takes in a vararg of character lists. It’s also been renamed as `setCharacterLists` (plural).

Supporting variable number of character lists have several advantages.
1. We don't have to specify the animation behavior from all possible characters.
2. Characters that do not exist in any character list can be treated differently by the animator.
   e.g. always prioritize preserving them via ACTION_SAME so they do not get animated.
3. Can support more custom animation behavior since each character list gets priority over the previous.
   e.g. [0, 1, 2] dictates animation behavior from 0 to 2, but what if I want a different behavior
   from 1 to 2? I can provide another character list that's something like [1, 3, 2].
4. Can support wrapping around behavior where 9 -> 0 properly wraps around the list rather than
   going all the way down. This is currently not possible because wrap-around in the current
   scenario would mean it would animate through all of the non-number characters (e.g. `$`).


closes #67 