### PR TITLE
Remove unnecessary synchronized modifier. 

### DIFF
--- a/ticker/src/main/java/com/robinhood/ticker/TickerView.java
+++ b/ticker/src/main/java/com/robinhood/ticker/TickerView.java
@@ -285,7 +285,7 @@ public class TickerView extends View {
      * @param text the text to display.
      * @param animate whether to animate to text.
      */
-    public synchronized void setText(String text, boolean animate) {
+    public void setText(String text, boolean animate) {
         if (TextUtils.equals(text, this.text)) {
             return;
         }


### PR DESCRIPTION
`TickerView.setText()` is only safe to call from the thread that created the `TickerView` since it calls `invalidate()`. Calling from a different thread results in:

```
android.view.ViewRootImpl$CalledFromWrongThreadException: Only the original thread that created a view hierarchy can touch its views.
```

There doesn't appear to be a benefit from synchronizing this method and doing so has a non-zero cost. Thoughts on removing it?