### PR TITLE
Modernize build dependencies.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Getting started
 Add the ticker dependency to your `build.gradle`.
 
 ```groovy
-compile 'com.robinhood.ticker:ticker:1.2.2'
+implementation 'com.robinhood.ticker:ticker:1.2.2'
 ```
 
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip

--- a/ticker-sample/build.gradle
+++ b/ticker-sample/build.gradle
@@ -1,19 +1,19 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 26
+    compileSdkVersion 27
     buildToolsVersion '26.0.2'
 
     defaultConfig {
         applicationId "com.robinhood.ticker.sample"
         minSdkVersion 14
-        targetSdkVersion 26
+        targetSdkVersion 27
     }
 }
 
 dependencies {
     implementation project(':ticker')
 
-    implementation 'com.android.support:appcompat-v7:26.1.0'
-    implementation 'com.android.support:recyclerview-v7:26.1.0'
+    implementation 'com.android.support:appcompat-v7:27.0.2'
+    implementation 'com.android.support:recyclerview-v7:27.0.2'
 }

--- a/ticker/build.gradle
+++ b/ticker/build.gradle
@@ -14,7 +14,7 @@ android {
 
 dependencies {
     testImplementation 'junit:junit:4.12'
-    testImplementation 'org.mockito:mockito-core:2.10.0'
+    testImplementation 'org.mockito:mockito-core:2.13.0'
 }
 
 apply from: './gradle-mvn-push.gradle'


### PR DESCRIPTION
Few small updates here:

- Moves to Gradle 4.4 
- Makes the sample app target Android Oreo Go edition
- Bumps Mockito
- Moves README to use `implementation` over `compile` (like [OkHttp](https://github.com/square/okhttp))