### PR TITLE
Update documentation for setTextSize

### DIFF
--- a/ticker/src/main/java/com/robinhood/ticker/TickerView.java
+++ b/ticker/src/main/java/com/robinhood/ticker/TickerView.java
@@ -359,7 +359,7 @@ public class TickerView extends View {
      * Sets the text size used by this view. The default text size is defined by
      * {@link #DEFAULT_TEXT_SIZE}.
      *
-     * @param textSize the text size to set the text to.
+     * @param textSize the text size in pixel units.
      */
     public void setTextSize(float textSize) {
         if (this.textSize != textSize) {


### PR DESCRIPTION
I was wondering about the unit on which setTextSize uses to set the text and I expect it to be on the method documentation as it sometimes gets confusing. I would also suggest making another overloaded method like TextView's which have the unit as the first parameter
`text.setTextSize(TypedValue.COMPLEX_UNIT_SP, 14)` I could do the change if it looks interesting :)