### PR TITLE
Preferred TickerColumn Scrolling Direction

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ tickerView.setTypeface(myCustomTypeface);
 tickerView.setAnimationDuration(500);
 tickerView.setAnimationInterpolator(new OvershootInterpolator());
 tickerView.setGravity(Gravity.START);
-tickerView.setPreferredScrollingDirection(TickerView.DIRECTION_ANY);
+tickerView.setPreferredScrollingDirection(TickerView.ScrollingDirection.ANY);
 ```
 
 For the full list of XML attributes that we support, please refer to the 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ android:gravity="center"
 android:textColor="@color/colorPrimary"
 android:textSize="16sp"
 app:ticker_animationDuration="1500"
+app:ticker_preferredScrollingDirection="any"
 ```
 
 Or Java:
@@ -79,6 +80,7 @@ tickerView.setTypeface(myCustomTypeface);
 tickerView.setAnimationDuration(500);
 tickerView.setAnimationInterpolator(new OvershootInterpolator());
 tickerView.setGravity(Gravity.START);
+tickerView.setPreferredScrollingDirection(TickerView.DIRECTION_ANY);
 ```
 
 For the full list of XML attributes that we support, please refer to the 

--- a/ticker-sample/src/main/java/com/robinhood/ticker/sample/MainActivity.java
+++ b/ticker-sample/src/main/java/com/robinhood/ticker/sample/MainActivity.java
@@ -22,6 +22,10 @@ public class MainActivity extends BaseActivity {
         ticker2 = findViewById(R.id.ticker2);
         ticker3 = findViewById(R.id.ticker3);
 
+        ticker1.setPreferredScrollingDirection(TickerView.DIRECTION_DOWN);
+        ticker2.setPreferredScrollingDirection(TickerView.DIRECTION_UP);
+        ticker3.setPreferredScrollingDirection(TickerView.DIRECTION_ANY);
+
         findViewById(R.id.perfBtn).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {

--- a/ticker-sample/src/main/java/com/robinhood/ticker/sample/MainActivity.java
+++ b/ticker-sample/src/main/java/com/robinhood/ticker/sample/MainActivity.java
@@ -22,9 +22,9 @@ public class MainActivity extends BaseActivity {
         ticker2 = findViewById(R.id.ticker2);
         ticker3 = findViewById(R.id.ticker3);
 
-        ticker1.setPreferredScrollingDirection(TickerView.DIRECTION_DOWN);
-        ticker2.setPreferredScrollingDirection(TickerView.DIRECTION_UP);
-        ticker3.setPreferredScrollingDirection(TickerView.DIRECTION_ANY);
+        ticker1.setPreferredScrollingDirection(TickerView.ScrollingDirection.DOWN);
+        ticker2.setPreferredScrollingDirection(TickerView.ScrollingDirection.UP);
+        ticker3.setPreferredScrollingDirection(TickerView.ScrollingDirection.ANY);
 
         findViewById(R.id.perfBtn).setOnClickListener(new View.OnClickListener() {
             @Override

--- a/ticker/src/main/java/com/robinhood/ticker/TickerCharacterList.java
+++ b/ticker/src/main/java/com/robinhood/ticker/TickerCharacterList.java
@@ -64,33 +64,55 @@ class TickerCharacterList {
     /**
      * @param start the character that we want to animate from
      * @param end the character that we want to animate to
+     * @param preferredDirection the preferred scrolling direction
      * @return a valid pair of start and end indices, or null if the inputs are not supported.
      */
-    CharacterIndices getCharacterIndices(char start, char end) {
+    CharacterIndices getCharacterIndices(char start, char end, int preferredDirection) {
         int startIndex = getIndexOfChar(start);
         int endIndex = getIndexOfChar(end);
+
         if (startIndex < 0 || endIndex < 0) {
             return null;
         }
 
-        // see if the wrap-around animation is shorter distance than the original animation
-        if (start != TickerUtils.EMPTY_CHAR && end != TickerUtils.EMPTY_CHAR) {
-            if (endIndex < startIndex) {
-                // If we are potentially going backwards
-                final int nonWrapDistance = startIndex - endIndex;
-                final int wrapDistance = numOriginalCharacters - startIndex + endIndex;
-                if (wrapDistance < nonWrapDistance) {
+        switch (preferredDirection) {
+            case TickerView.DIRECTION_DOWN:
+                if (end == TickerUtils.EMPTY_CHAR) {
+                    endIndex = characterList.length;
+                } else if (endIndex < startIndex) {
                     endIndex += numOriginalCharacters;
                 }
-            } else if (startIndex < endIndex) {
-                // If we are potentially going forwards
-                final int nonWrapDistance = endIndex - startIndex;
-                final int wrapDistance = numOriginalCharacters - endIndex + startIndex;
-                if (wrapDistance < nonWrapDistance) {
+
+                break;
+            case TickerView.DIRECTION_UP:
+                if (startIndex < endIndex) {
                     startIndex += numOriginalCharacters;
                 }
-            }
+
+                break;
+            default:
+                // see if the wrap-around animation is shorter distance than the original animation
+                if (start != TickerUtils.EMPTY_CHAR && end != TickerUtils.EMPTY_CHAR) {
+                    if (endIndex < startIndex) {
+                        // If we are potentially going backwards
+                        final int nonWrapDistance = startIndex - endIndex;
+                        final int wrapDistance = numOriginalCharacters - startIndex + endIndex;
+                        if (wrapDistance < nonWrapDistance) {
+                            endIndex += numOriginalCharacters;
+                        }
+                    } else if (startIndex < endIndex) {
+                        // If we are potentially going forwards
+                        final int nonWrapDistance = endIndex - startIndex;
+                        final int wrapDistance = numOriginalCharacters - endIndex + startIndex;
+                        if (wrapDistance < nonWrapDistance) {
+                            startIndex += numOriginalCharacters;
+                        }
+                    }
+                }
+
+                break;
         }
+
         return new CharacterIndices(startIndex, endIndex);
     }
 

--- a/ticker/src/main/java/com/robinhood/ticker/TickerCharacterList.java
+++ b/ticker/src/main/java/com/robinhood/ticker/TickerCharacterList.java
@@ -64,10 +64,10 @@ class TickerCharacterList {
     /**
      * @param start the character that we want to animate from
      * @param end the character that we want to animate to
-     * @param preferredDirection the preferred scrolling direction
+     * @param direction the preferred {@Link TickerView#ScrollingDirection}
      * @return a valid pair of start and end indices, or null if the inputs are not supported.
      */
-    CharacterIndices getCharacterIndices(char start, char end, int preferredDirection) {
+    CharacterIndices getCharacterIndices(char start, char end, TickerView.ScrollingDirection direction) {
         int startIndex = getIndexOfChar(start);
         int endIndex = getIndexOfChar(end);
 
@@ -75,8 +75,8 @@ class TickerCharacterList {
             return null;
         }
 
-        switch (preferredDirection) {
-            case TickerView.DIRECTION_DOWN:
+        switch (direction) {
+            case DOWN:
                 if (end == TickerUtils.EMPTY_CHAR) {
                     endIndex = characterList.length;
                 } else if (endIndex < startIndex) {
@@ -84,13 +84,13 @@ class TickerCharacterList {
                 }
 
                 break;
-            case TickerView.DIRECTION_UP:
+            case UP:
                 if (startIndex < endIndex) {
                     startIndex += numOriginalCharacters;
                 }
 
                 break;
-            case TickerView.DIRECTION_ANY:
+            case ANY:
                 // see if the wrap-around animation is shorter distance than the original animation
                 if (start != TickerUtils.EMPTY_CHAR && end != TickerUtils.EMPTY_CHAR) {
                     if (endIndex < startIndex) {
@@ -111,8 +111,6 @@ class TickerCharacterList {
                 }
 
                 break;
-            default:
-                throw new IllegalArgumentException("Unknown direction: " + preferredDirection);
         }
 
         return new CharacterIndices(startIndex, endIndex);

--- a/ticker/src/main/java/com/robinhood/ticker/TickerCharacterList.java
+++ b/ticker/src/main/java/com/robinhood/ticker/TickerCharacterList.java
@@ -90,7 +90,7 @@ class TickerCharacterList {
                 }
 
                 break;
-            default:
+            case TickerView.DIRECTION_ANY:
                 // see if the wrap-around animation is shorter distance than the original animation
                 if (start != TickerUtils.EMPTY_CHAR && end != TickerUtils.EMPTY_CHAR) {
                     if (endIndex < startIndex) {
@@ -111,6 +111,8 @@ class TickerCharacterList {
                 }
 
                 break;
+            default:
+                throw new IllegalArgumentException("Unknown direction: " + preferredDirection);
         }
 
         return new CharacterIndices(startIndex, endIndex);

--- a/ticker/src/main/java/com/robinhood/ticker/TickerColumn.java
+++ b/ticker/src/main/java/com/robinhood/ticker/TickerColumn.java
@@ -114,7 +114,7 @@ class TickerColumn {
 
         for (int i = 0; i < characterLists.length; i++) {
             final TickerCharacterList.CharacterIndices indices =
-                    characterLists[i].getCharacterIndices(currentChar, targetChar);
+                    characterLists[i].getCharacterIndices(currentChar, targetChar, metrics.getPreferredScrollingDirection());
             if (indices != null) {
                 this.currentCharacterList = this.characterLists[i].getCharacterList();
                 this.startIndex = indices.startIndex;

--- a/ticker/src/main/java/com/robinhood/ticker/TickerDrawMetrics.java
+++ b/ticker/src/main/java/com/robinhood/ticker/TickerDrawMetrics.java
@@ -36,7 +36,7 @@ class TickerDrawMetrics {
     private final Map<Character, Float> charWidths = new HashMap<>(256);
     private float charHeight, charBaseline;
 
-    private int preferredScrollingDirection = TickerView.DIRECTION_ANY;
+    private TickerView.ScrollingDirection preferredScrollingDirection = TickerView.ScrollingDirection.ANY;
 
     TickerDrawMetrics(Paint textPaint) {
         this.textPaint = textPaint;
@@ -74,11 +74,11 @@ class TickerDrawMetrics {
         return charBaseline;
     }
 
-    int getPreferredScrollingDirection() {
+    TickerView.ScrollingDirection getPreferredScrollingDirection() {
         return preferredScrollingDirection;
     }
 
-    void setPreferredScrollingDirection(int preferredScrollingDirection) {
+    void setPreferredScrollingDirection(TickerView.ScrollingDirection preferredScrollingDirection) {
         this.preferredScrollingDirection = preferredScrollingDirection;
     }
 }

--- a/ticker/src/main/java/com/robinhood/ticker/TickerDrawMetrics.java
+++ b/ticker/src/main/java/com/robinhood/ticker/TickerDrawMetrics.java
@@ -36,6 +36,8 @@ class TickerDrawMetrics {
     private final Map<Character, Float> charWidths = new HashMap<>(256);
     private float charHeight, charBaseline;
 
+    private int preferredScrollingDirection = TickerView.DIRECTION_ANY;
+
     TickerDrawMetrics(Paint textPaint) {
         this.textPaint = textPaint;
         invalidate();
@@ -70,5 +72,13 @@ class TickerDrawMetrics {
 
     float getCharBaseline() {
         return charBaseline;
+    }
+
+    int getPreferredScrollingDirection() {
+        return preferredScrollingDirection;
+    }
+
+    void setPreferredScrollingDirection(int preferredScrollingDirection) {
+        this.preferredScrollingDirection = preferredScrollingDirection;
     }
 }

--- a/ticker/src/main/java/com/robinhood/ticker/TickerView.java
+++ b/ticker/src/main/java/com/robinhood/ticker/TickerView.java
@@ -57,16 +57,17 @@ import android.view.animation.Interpolator;
  * @author Jin Cao, Robinhood
  */
 public class TickerView extends View {
+
+    public enum ScrollingDirection {
+        ANY, UP, DOWN
+    }
+
     private static final int DEFAULT_TEXT_SIZE = 12;
     private static final int DEFAULT_TEXT_COLOR = Color.BLACK;
     private static final int DEFAULT_ANIMATION_DURATION = 350;
     private static final Interpolator DEFAULT_ANIMATION_INTERPOLATOR =
             new AccelerateDecelerateInterpolator();
     private static final int DEFAULT_GRAVITY = Gravity.START;
-
-    public static final int DIRECTION_ANY = 0;
-    public static final int DIRECTION_UP = 1;
-    public static final int DIRECTION_DOWN = 2;
 
     protected final Paint textPaint = new TextPaint(Paint.ANTI_ALIAS_FLAG);
 
@@ -184,9 +185,21 @@ public class TickerView extends View {
         }
 
         final int defaultPreferredScrollingDirection =
-                arr.getInt(R.styleable.TickerView_ticker_defaultPreferredScrollingDirection, DIRECTION_ANY);
+                arr.getInt(R.styleable.TickerView_ticker_defaultPreferredScrollingDirection, 0);
 
-        metrics.setPreferredScrollingDirection(defaultPreferredScrollingDirection);
+        switch (defaultPreferredScrollingDirection) {
+            case 0:
+                metrics.setPreferredScrollingDirection(ScrollingDirection.ANY);
+                break;
+            case 1:
+                metrics.setPreferredScrollingDirection(ScrollingDirection.UP);
+                break;
+            case 2:
+                metrics.setPreferredScrollingDirection(ScrollingDirection.DOWN);
+                break;
+            default:
+                throw new IllegalArgumentException("Unsupported ticker_defaultPreferredScrollingDirection: " + defaultPreferredScrollingDirection);
+        }
 
         if (isCharacterListsSet()) {
             setText(styledAttributes.text, false);
@@ -466,15 +479,15 @@ public class TickerView extends View {
 
     /**
      * Sets the preferred scrolling direction for ticker animations.
-     * Eligible params include {@link #DIRECTION_ANY}, {@link #DIRECTION_UP}
-     * and {@link #DIRECTION_DOWN}.
+     * Eligible params include {@link ScrollingDirection#ANY}, {@link ScrollingDirection#UP}
+     * and {@link ScrollingDirection#DOWN}.
      *
-     * The default value is {@link #DIRECTION_ANY}.
+     * The default value is {@link ScrollingDirection#ANY}.
      *
-     * @param preferredScrollingDirection the preferred scrolling directional
+     * @param direction the preferred {@link ScrollingDirection}
      */
-    public void setPreferredScrollingDirection(int preferredScrollingDirection) {
-        this.metrics.setPreferredScrollingDirection(preferredScrollingDirection);
+    public void setPreferredScrollingDirection(ScrollingDirection direction) {
+        this.metrics.setPreferredScrollingDirection(direction);
     }
 
     /**

--- a/ticker/src/main/java/com/robinhood/ticker/TickerView.java
+++ b/ticker/src/main/java/com/robinhood/ticker/TickerView.java
@@ -183,6 +183,11 @@ public class TickerView extends View {
                 }
         }
 
+        final int defaultPreferredScrollingDirection =
+                arr.getInt(R.styleable.TickerView_ticker_defaultPreferredScrollingDirection, DIRECTION_ANY);
+
+        metrics.setPreferredScrollingDirection(defaultPreferredScrollingDirection);
+
         if (isCharacterListsSet()) {
             setText(styledAttributes.text, false);
         } else {

--- a/ticker/src/main/java/com/robinhood/ticker/TickerView.java
+++ b/ticker/src/main/java/com/robinhood/ticker/TickerView.java
@@ -64,6 +64,10 @@ public class TickerView extends View {
             new AccelerateDecelerateInterpolator();
     private static final int DEFAULT_GRAVITY = Gravity.START;
 
+    public static final int DIRECTION_ANY = 0;
+    public static final int DIRECTION_UP = 1;
+    public static final int DIRECTION_DOWN = 2;
+
     protected final Paint textPaint = new TextPaint(Paint.ANTI_ALIAS_FLAG);
 
     private final TickerDrawMetrics metrics = new TickerDrawMetrics(textPaint);
@@ -453,6 +457,19 @@ public class TickerView extends View {
      */
     public void setAnimationInterpolator(Interpolator animationInterpolator) {
         this.animationInterpolator = animationInterpolator;
+    }
+
+    /**
+     * Sets the preferred scrolling direction for ticker animations.
+     * Eligible params include {@link #DIRECTION_ANY}, {@link #DIRECTION_UP}
+     * and {@link #DIRECTION_DOWN}.
+     *
+     * The default value is {@link #DIRECTION_ANY}.
+     *
+     * @param preferredScrollingDirection the preferred scrolling directional
+     */
+    public void setPreferredScrollingDirection(int preferredScrollingDirection) {
+        this.metrics.setPreferredScrollingDirection(preferredScrollingDirection);
     }
 
     /**

--- a/ticker/src/main/res/values/attrs.xml
+++ b/ticker/src/main/res/values/attrs.xml
@@ -7,6 +7,11 @@
             <enum name="number" value="1" />
             <enum name="alphabet" value="2" />
         </attr>
+        <attr name="ticker_defaultPreferredScrollingDirection" format="enum">
+            <enum name="any" value="0" />
+            <enum name="up" value="1" />
+            <enum name="down" value="2" />
+        </attr>
 
         <!-- Custom implementations of common android text attributes -->
         <attr name="android:gravity" tools:ignore="ResourceName" />

--- a/ticker/src/test/java/com/robinhood/ticker/TickerCharacterListTest.java
+++ b/ticker/src/test/java/com/robinhood/ticker/TickerCharacterListTest.java
@@ -39,11 +39,45 @@ public class TickerCharacterListTest {
     }
 
     @Test
+    public void test_getCharacterIndicesForcedDown() {
+        final TickerCharacterList list = new TickerCharacterList("012");
+        final TickerCharacterList.CharacterIndices indices = list.getCharacterIndices('2', '0', TickerView.DIRECTION_DOWN);
+        assertEquals(3, indices.startIndex);
+        assertEquals(4, indices.endIndex);
+    }
+
+    @Test
+    public void test_getCharacterIndicesForcedUp() {
+        final TickerCharacterList list = new TickerCharacterList("012");
+        final TickerCharacterList.CharacterIndices indices = list.getCharacterIndices('0', '2', TickerView.DIRECTION_UP);
+        assertEquals(4, indices.startIndex);
+        assertEquals(3, indices.endIndex);
+    }
+
+    @Test
     public void test_getCharacterIndicesEmptyNoWraparound() {
         final TickerCharacterList list = new TickerCharacterList("012");
         final TickerCharacterList.CharacterIndices indices =
                 list.getCharacterIndices('2', TickerUtils.EMPTY_CHAR, TickerView.DIRECTION_ANY);
         assertEquals(3, indices.startIndex);
         assertEquals(0, indices.endIndex);
+    }
+
+    @Test
+    public void test_getCharacterIndicesEmptyForcedUp() {
+        final TickerCharacterList list = new TickerCharacterList("012");
+        final TickerCharacterList.CharacterIndices indices =
+                list.getCharacterIndices('2', TickerUtils.EMPTY_CHAR, TickerView.DIRECTION_UP);
+        assertEquals(3, indices.startIndex);
+        assertEquals(0, indices.endIndex);
+    }
+
+    @Test
+    public void test_getCharacterIndicesEmptyForcedDown() {
+        final TickerCharacterList list = new TickerCharacterList("012");
+        final TickerCharacterList.CharacterIndices indices =
+                list.getCharacterIndices('2', TickerUtils.EMPTY_CHAR, TickerView.DIRECTION_DOWN);
+        assertEquals(3, indices.startIndex);
+        assertEquals(7, indices.endIndex);
     }
 }

--- a/ticker/src/test/java/com/robinhood/ticker/TickerCharacterListTest.java
+++ b/ticker/src/test/java/com/robinhood/ticker/TickerCharacterListTest.java
@@ -17,7 +17,7 @@ public class TickerCharacterListTest {
     @Test
     public void test_getCharacterIndices() {
         final TickerCharacterList list = new TickerCharacterList("012");
-        final TickerCharacterList.CharacterIndices indices = list.getCharacterIndices('0', '1', TickerView.DIRECTION_ANY);
+        final TickerCharacterList.CharacterIndices indices = list.getCharacterIndices('0', '1', TickerView.ScrollingDirection.ANY);
         assertEquals(1, indices.startIndex);
         assertEquals(2, indices.endIndex);
     }
@@ -25,7 +25,7 @@ public class TickerCharacterListTest {
     @Test
     public void test_getCharacterIndicesWraparound() {
         final TickerCharacterList list = new TickerCharacterList("012");
-        final TickerCharacterList.CharacterIndices indices = list.getCharacterIndices('2', '0', TickerView.DIRECTION_ANY);
+        final TickerCharacterList.CharacterIndices indices = list.getCharacterIndices('2', '0', TickerView.ScrollingDirection.ANY);
         assertEquals(3, indices.startIndex);
         assertEquals(4, indices.endIndex);
     }
@@ -33,7 +33,7 @@ public class TickerCharacterListTest {
     @Test
     public void test_getCharacterIndicesWraparound2() {
         final TickerCharacterList list = new TickerCharacterList("012");
-        final TickerCharacterList.CharacterIndices indices = list.getCharacterIndices('0', '2', TickerView.DIRECTION_ANY);
+        final TickerCharacterList.CharacterIndices indices = list.getCharacterIndices('0', '2', TickerView.ScrollingDirection.ANY);
         assertEquals(4, indices.startIndex);
         assertEquals(3, indices.endIndex);
     }
@@ -41,7 +41,7 @@ public class TickerCharacterListTest {
     @Test
     public void test_getCharacterIndicesForcedDown() {
         final TickerCharacterList list = new TickerCharacterList("012");
-        final TickerCharacterList.CharacterIndices indices = list.getCharacterIndices('2', '0', TickerView.DIRECTION_DOWN);
+        final TickerCharacterList.CharacterIndices indices = list.getCharacterIndices('2', '0', TickerView.ScrollingDirection.DOWN);
         assertEquals(3, indices.startIndex);
         assertEquals(4, indices.endIndex);
     }
@@ -49,7 +49,7 @@ public class TickerCharacterListTest {
     @Test
     public void test_getCharacterIndicesForcedDown2() {
         final TickerCharacterList list = new TickerCharacterList("012");
-        final TickerCharacterList.CharacterIndices indices = list.getCharacterIndices('0', '2', TickerView.DIRECTION_DOWN);
+        final TickerCharacterList.CharacterIndices indices = list.getCharacterIndices('0', '2', TickerView.ScrollingDirection.DOWN);
         assertEquals(1, indices.startIndex);
         assertEquals(3, indices.endIndex);
     }
@@ -57,7 +57,7 @@ public class TickerCharacterListTest {
     @Test
     public void test_getCharacterIndicesForcedUp() {
         final TickerCharacterList list = new TickerCharacterList("012");
-        final TickerCharacterList.CharacterIndices indices = list.getCharacterIndices('2', '0', TickerView.DIRECTION_UP);
+        final TickerCharacterList.CharacterIndices indices = list.getCharacterIndices('2', '0', TickerView.ScrollingDirection.UP);
         assertEquals(3, indices.startIndex);
         assertEquals(1, indices.endIndex);
     }
@@ -65,7 +65,7 @@ public class TickerCharacterListTest {
     @Test
     public void test_getCharacterIndicesForcedUp2() {
         final TickerCharacterList list = new TickerCharacterList("012");
-        final TickerCharacterList.CharacterIndices indices = list.getCharacterIndices('0', '2', TickerView.DIRECTION_UP);
+        final TickerCharacterList.CharacterIndices indices = list.getCharacterIndices('0', '2', TickerView.ScrollingDirection.UP);
         assertEquals(4, indices.startIndex);
         assertEquals(3, indices.endIndex);
     }
@@ -74,7 +74,7 @@ public class TickerCharacterListTest {
     public void test_getCharacterIndicesEmptyNoWraparound() {
         final TickerCharacterList list = new TickerCharacterList("012");
         final TickerCharacterList.CharacterIndices indices =
-                list.getCharacterIndices('2', TickerUtils.EMPTY_CHAR, TickerView.DIRECTION_ANY);
+                list.getCharacterIndices('2', TickerUtils.EMPTY_CHAR, TickerView.ScrollingDirection.ANY);
         assertEquals(3, indices.startIndex);
         assertEquals(0, indices.endIndex);
     }
@@ -83,7 +83,7 @@ public class TickerCharacterListTest {
     public void test_getCharacterIndicesEmptyForcedUp() {
         final TickerCharacterList list = new TickerCharacterList("012");
         final TickerCharacterList.CharacterIndices indices =
-                list.getCharacterIndices('2', TickerUtils.EMPTY_CHAR, TickerView.DIRECTION_UP);
+                list.getCharacterIndices('2', TickerUtils.EMPTY_CHAR, TickerView.ScrollingDirection.UP);
         assertEquals(3, indices.startIndex);
         assertEquals(0, indices.endIndex);
     }
@@ -92,7 +92,7 @@ public class TickerCharacterListTest {
     public void test_getCharacterIndicesEmptyForcedDown() {
         final TickerCharacterList list = new TickerCharacterList("012");
         final TickerCharacterList.CharacterIndices indices =
-                list.getCharacterIndices('2', TickerUtils.EMPTY_CHAR, TickerView.DIRECTION_DOWN);
+                list.getCharacterIndices('2', TickerUtils.EMPTY_CHAR, TickerView.ScrollingDirection.DOWN);
         assertEquals(3, indices.startIndex);
         assertEquals(7, indices.endIndex);
     }

--- a/ticker/src/test/java/com/robinhood/ticker/TickerCharacterListTest.java
+++ b/ticker/src/test/java/com/robinhood/ticker/TickerCharacterListTest.java
@@ -17,7 +17,7 @@ public class TickerCharacterListTest {
     @Test
     public void test_getCharacterIndices() {
         final TickerCharacterList list = new TickerCharacterList("012");
-        final TickerCharacterList.CharacterIndices indices = list.getCharacterIndices('0', '1');
+        final TickerCharacterList.CharacterIndices indices = list.getCharacterIndices('0', '1', TickerView.DIRECTION_ANY);
         assertEquals(1, indices.startIndex);
         assertEquals(2, indices.endIndex);
     }
@@ -25,7 +25,7 @@ public class TickerCharacterListTest {
     @Test
     public void test_getCharacterIndicesWraparound() {
         final TickerCharacterList list = new TickerCharacterList("012");
-        final TickerCharacterList.CharacterIndices indices = list.getCharacterIndices('2', '0');
+        final TickerCharacterList.CharacterIndices indices = list.getCharacterIndices('2', '0', TickerView.DIRECTION_ANY);
         assertEquals(3, indices.startIndex);
         assertEquals(4, indices.endIndex);
     }
@@ -33,7 +33,7 @@ public class TickerCharacterListTest {
     @Test
     public void test_getCharacterIndicesWraparound2() {
         final TickerCharacterList list = new TickerCharacterList("012");
-        final TickerCharacterList.CharacterIndices indices = list.getCharacterIndices('0', '2');
+        final TickerCharacterList.CharacterIndices indices = list.getCharacterIndices('0', '2', TickerView.DIRECTION_ANY);
         assertEquals(4, indices.startIndex);
         assertEquals(3, indices.endIndex);
     }
@@ -42,7 +42,7 @@ public class TickerCharacterListTest {
     public void test_getCharacterIndicesEmptyNoWraparound() {
         final TickerCharacterList list = new TickerCharacterList("012");
         final TickerCharacterList.CharacterIndices indices =
-                list.getCharacterIndices('2', TickerUtils.EMPTY_CHAR);
+                list.getCharacterIndices('2', TickerUtils.EMPTY_CHAR, TickerView.DIRECTION_ANY);
         assertEquals(3, indices.startIndex);
         assertEquals(0, indices.endIndex);
     }

--- a/ticker/src/test/java/com/robinhood/ticker/TickerCharacterListTest.java
+++ b/ticker/src/test/java/com/robinhood/ticker/TickerCharacterListTest.java
@@ -47,7 +47,23 @@ public class TickerCharacterListTest {
     }
 
     @Test
+    public void test_getCharacterIndicesForcedDown2() {
+        final TickerCharacterList list = new TickerCharacterList("012");
+        final TickerCharacterList.CharacterIndices indices = list.getCharacterIndices('0', '2', TickerView.DIRECTION_DOWN);
+        assertEquals(1, indices.startIndex);
+        assertEquals(3, indices.endIndex);
+    }
+
+    @Test
     public void test_getCharacterIndicesForcedUp() {
+        final TickerCharacterList list = new TickerCharacterList("012");
+        final TickerCharacterList.CharacterIndices indices = list.getCharacterIndices('2', '0', TickerView.DIRECTION_UP);
+        assertEquals(3, indices.startIndex);
+        assertEquals(1, indices.endIndex);
+    }
+
+    @Test
+    public void test_getCharacterIndicesForcedUp2() {
         final TickerCharacterList list = new TickerCharacterList("012");
         final TickerCharacterList.CharacterIndices indices = list.getCharacterIndices('0', '2', TickerView.DIRECTION_UP);
         assertEquals(4, indices.startIndex);

--- a/ticker/src/test/java/com/robinhood/ticker/TickerColumnManagerTest.java
+++ b/ticker/src/test/java/com/robinhood/ticker/TickerColumnManagerTest.java
@@ -20,6 +20,7 @@ public class TickerColumnManagerTest {
 
         when(metrics.getCharWidth(anyChar())).thenReturn(5f);
         when(metrics.getCharWidth(TickerUtils.EMPTY_CHAR)).thenReturn(0f);
+        when(metrics.getPreferredScrollingDirection()).thenReturn(TickerView.ScrollingDirection.ANY);
 
         tickerColumnManager = new TickerColumnManager(metrics);
         tickerColumnManager.setCharacterLists("1234567890");

--- a/ticker/src/test/java/com/robinhood/ticker/TickerColumnTest.java
+++ b/ticker/src/test/java/com/robinhood/ticker/TickerColumnTest.java
@@ -35,6 +35,8 @@ public class TickerColumnTest {
         when(metrics.getCharHeight()).thenReturn(CHAR_HEIGHT);
         when(metrics.getCharWidth(anyChar())).thenReturn(DEFAULT_CHAR_WIDTH);
         when(metrics.getCharWidth(TickerUtils.EMPTY_CHAR)).thenReturn(0f);
+        when(metrics.getPreferredScrollingDirection()).thenReturn(TickerView.ScrollingDirection.ANY);
+
         tickerColumn = new TickerColumn(
                 new TickerCharacterList[] { characterList },
                 metrics


### PR DESCRIPTION
This PR [fixes #97](https://github.com/robinhood/ticker/issues/97) by introducing the ability to enforce a preferred scrolling direction when animating `TickerColumn` changes. 

The direction can be set by calling `TickerView.setPreferredScrollingDirection(int)` with values of `TickerView.DIRECTION_ANY`, `TickerView.DIRECTION_UP`, or `TickerView.DIRECTION_DOWN`. It can also be set via XML via `::ticker_defaultPreferredScrollingDirection` with values of `any`, `up`, or `down`. The default behavior of the scrolling animation is what it currently is before the introduction of this PR (TickerView.DIRECTION_ANY).

The direction is stored within the `TickerDrawMetrics` and is retrievable via `TickerDrawMetrics.getPreferredScrollingDirection()`.

This PR also updates the `TickerCharacterListTest` tests to explicitly define their target direction, and adds several tests for the enforced up/down scrolling behavior.

I also left some sample calls within ticker-sample, but was unsure if you'd prefer to leave them out.