### PR TITLE
Add/remove blur mask filter

### DIFF
--- a/ticker/src/main/java/com/robinhood/ticker/TickerView.java
+++ b/ticker/src/main/java/com/robinhood/ticker/TickerView.java
@@ -23,6 +23,7 @@ import android.annotation.TargetApi;
 import android.content.Context;
 import android.content.res.Resources;
 import android.content.res.TypedArray;
+import android.graphics.BlurMaskFilter;
 import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Paint;
@@ -554,6 +555,22 @@ public class TickerView extends View {
      */
     public void removeAnimatorListener(Animator.AnimatorListener animatorListener) {
         animator.removeListener(animatorListener);
+    }
+
+    /*
+     * Exposing method to add or remove blur mask filter to ticker text.
+     *
+     * @param style: Blur mask filter type
+     * @param radius: Density of filter
+     */
+    public void setBlurMaskFilter(BlurMaskFilter.Blur style, float radius) {
+        if (style != null && radius > 0f) {
+            BlurMaskFilter filter = new BlurMaskFilter(radius, style);
+            textPaint.setMaskFilter(filter);
+        } else {
+            setLayerType(View.LAYER_TYPE_SOFTWARE, null);
+            textPaint.setMaskFilter(null);
+        }
     }
 
 


### PR DESCRIPTION
# Changes
- Exposing method to add or remove blur mask filter to ticker text.

# Test
## Devices
- Samsung Galaxy S9 API 27 (emulator)

## TestCase - Adding blur mask
- Example call: `tickerView.setBlurMaskFilter(BlurMaskFilter.Blur.NORMAL, tickerView.textSize / 5)`
- Check:
  + Ticker text is blurred

## TestCase - Removing blur mask
- Example call: `tickerView.setBlurMaskFilter(null, 0f)`
- Check:
  + Ticker text is not blurred