### PR TITLE
Cancel animation when setText is called with animate=false

### DIFF
--- a/ticker/src/main/java/com/robinhood/ticker/TickerView.java
+++ b/ticker/src/main/java/com/robinhood/ticker/TickerView.java
@@ -326,6 +326,10 @@ public class TickerView extends View {
             return;
         }
 
+        if (animator.isRunning()) {
+            animator.cancel();
+        }
+
         this.text = text;
         final char[] targetText = text == null ? new char[0] : text.toCharArray();
 
@@ -334,10 +338,6 @@ public class TickerView extends View {
 
         if (animate) {
             // Kick off the animator that draws the transition
-            if (animator.isRunning()) {
-                animator.cancel();
-            }
-
             animator.setStartDelay(animationDelayInMillis);
             animator.setDuration(animationDurationInMillis);
             animator.setInterpolator(animationInterpolator);


### PR DESCRIPTION
If `TickerView.setText()` is called with `animate=false` and an existing animation is still in progress, the previous animation should be cancelled before setting the new text.