### PR TITLE
warning fix: Add "exported = true" to launcher activity

### DIFF
--- a/ticker-sample/src/main/AndroidManifest.xml
+++ b/ticker-sample/src/main/AndroidManifest.xml
@@ -6,7 +6,8 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:theme="@style/AppTheme">
-        <activity android:name=".MainActivity">
+        <activity android:name=".MainActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
 


### PR DESCRIPTION
# warning

<img width="842" alt="スクリーンショット 2021-10-17 14 54 40" src="https://user-images.githubusercontent.com/16476224/137613784-17d12098-c975-44cc-9651-72be709cb538.png">

# document (Android 12)

https://developer.android.com/about/versions/12/behavior-changes-12#exported