### PR TITLE
Fix text being stuck on old API levels

### DIFF
--- a/ticker/src/main/java/com/robinhood/ticker/TickerView.java
+++ b/ticker/src/main/java/com/robinhood/ticker/TickerView.java
@@ -222,6 +222,13 @@ public class TickerView extends View {
                 invalidate();
             }
         });
+
+        final Runnable startNextAnimation = new Runnable() {
+            @Override
+            public void run() {
+                startNextAnimation();
+            }
+        };
         animator.addListener(new AnimatorListenerAdapter() {
             @Override
             public void onAnimationEnd(Animator animation) {
@@ -229,12 +236,11 @@ public class TickerView extends View {
                 checkForRelayout();
                 invalidate();
 
-                post(new Runnable() {
-                    @Override
-                    public void run() {
-                        startNextAnimation();
-                    }
-                });
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                    startNextAnimation.run();
+                } else {
+                    post(startNextAnimation);
+                }
             }
         });
     }

--- a/ticker/src/main/java/com/robinhood/ticker/TickerView.java
+++ b/ticker/src/main/java/com/robinhood/ticker/TickerView.java
@@ -228,7 +228,13 @@ public class TickerView extends View {
                 columnManager.onAnimationEnd();
                 checkForRelayout();
                 invalidate();
-                startNextAnimation();
+
+                post(new Runnable() {
+                    @Override
+                    public void run() {
+                        startNextAnimation();
+                    }
+                });
             }
         });
     }


### PR DESCRIPTION
There's a bug where the text becomes stuck because `startNextAnimation` tries starting the animation, but nothing happens (so we think the animation runs forever).

My guess is that on old API levels, the animation isn't considered done while inside the onAnimationEnd callback, so `start` does nothing. The solution is to let the callback finish and then run the next animation afterwards by posting it.

I confirmed that this fixes the issue on an API 24 emulator.